### PR TITLE
Layout and disable fixes + new action feature

### DIFF
--- a/src/lib/components/button/QBtn.svelte
+++ b/src/lib/components/button/QBtn.svelte
@@ -1,8 +1,10 @@
 <script lang="ts">
   import { createClasses } from "$lib/utils/props";
+  import { createEventDispatcher } from "svelte";
   import QIcon from "../icon/QIcon.svelte";
   import QCircularProgress from "../progress/QCircularProgress.svelte";
   import type { QBtnProps } from "./props";
+  import { activationHandler } from "$lib/helpers/activationHandler";
 
   export let icon: QBtnProps["icon"] = undefined,
     label: QBtnProps["label"] = undefined,
@@ -16,6 +18,8 @@
     size: QBtnProps["size"] = undefined,
     userClasses: QBtnProps["userClasses"] = undefined;
   export { userClasses as class };
+
+  const emit = createEventDispatcher();
 
   let tag: "a" | "div";
   $: tag = to !== undefined ? "a" : "div";
@@ -38,13 +42,13 @@
 
 <svelte:element
   this={tag}
+  use:activationHandler={{ disable, callback: (e) => emit("activated", e) }}
   role="button"
   href={to}
   class={classes}
   aria-disabled={disable || undefined}
   tabindex={disable ? -1 : 0}
   {...$$restProps}
-  on:click
 >
   {#if icon && !loading}
     {#if icon.startsWith("img:")}

--- a/src/lib/components/chip/QChip.svelte
+++ b/src/lib/components/chip/QChip.svelte
@@ -1,5 +1,7 @@
 <script lang="ts">
+  import { activationHandler } from "$lib/helpers/activationHandler";
   import { createClasses } from "$lib/utils/props";
+  import { createEventDispatcher } from "svelte";
   import QIcon from "../icon/QIcon.svelte";
   import type { QChipProps } from "./props";
 
@@ -16,6 +18,8 @@
     href: QChipProps["href"] = undefined,
     userClasses: QChipProps["userClasses"] = undefined;
   export { userClasses as class };
+
+  const emit = createEventDispatcher();
 
   $: img = icon?.startsWith("img:") ? icon.slice(4) : undefined;
   $: imgRight = iconRight?.startsWith("img:") ? iconRight.slice(4) : undefined;
@@ -35,15 +39,15 @@
     element: "img",
   });
 
-  $: tab = typeof tabindex === "string" ? parseInt(tabindex, 10) : tabindex;
+  $: tab = disable ? -1 : tabindex ?? 0;
 </script>
 
 <a
+  use:activationHandler={{ disable, callback: (e) => emit("activated", e) }}
   {href}
   class={classes}
   tabindex={tab}
   {...$$restProps}
-  on:click
   aria-disabled={disable || undefined}
 >
   {#if $$slots.leading}

--- a/src/lib/components/chip/props.ts
+++ b/src/lib/components/chip/props.ts
@@ -61,7 +61,7 @@ export interface QChipProps extends NativeProps {
    * Tabindex of the chip.
    * @default undefined
    */
-  tabindex?: string | number;
+  tabindex?: number;
 
   /**
    * Makes the chip navigational. Can be used with the router (e.g to="/home") or as a normal href attribute (e.g to="#section-id").

--- a/src/lib/components/layout/index.scss
+++ b/src/lib/components/layout/index.scss
@@ -173,7 +173,7 @@
     }
   }
 
-  & > .q-list > .q-item.q-link {
+  & .q-list > .q-item.q-link {
     border-radius: 2rem;
 
     &::before {

--- a/src/lib/css/states.scss
+++ b/src/lib/css/states.scss
@@ -2,12 +2,8 @@
 .disabled {
   opacity: 0.5;
   cursor: not-allowed;
-
-  & * {
-    pointer-events: none;
-  }
-
-  &::after {
+  
+  &::before, &::after {
     all: unset;
   }
 }

--- a/src/lib/helpers/activationHandler.ts
+++ b/src/lib/helpers/activationHandler.ts
@@ -1,0 +1,32 @@
+type Event = MouseEvent | KeyboardEvent;
+interface Options {
+  disable: boolean | undefined;
+  callback: (e: Event) => void;
+}
+
+export function activationHandler(node: HTMLElement, { disable, callback }: Options) {
+  function handleEvent(event: Event) {
+    if (disable) {
+      event.preventDefault();
+      event.stopPropagation();
+      return;
+    }
+
+    if (event instanceof KeyboardEvent) {
+      if (!["Enter", "Space"].includes(event.code)) return;
+    }
+
+    event.preventDefault();
+    callback(event);
+  }
+
+  node.addEventListener("click", handleEvent);
+  node.addEventListener("keydown", handleEvent);
+
+  return {
+    destroy() {
+      node.removeEventListener("click", handleEvent);
+      node.removeEventListener("keydown", handleEvent);
+    },
+  };
+}

--- a/src/lib/helpers/index.ts
+++ b/src/lib/helpers/index.ts
@@ -1,1 +1,2 @@
 export * from "./clickOutside";
+export * from "./activationHandler";

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -118,8 +118,6 @@
   ];
   let contentEl: HTMLDivElement;
 
-  $: console.log($Quaff.router.url.pathname);
-
   let selectedRailbarItem: "components" | "utils" | null;
   $: selectedRailbarItem = isRouteActive($Quaff.router, "/components")
     ? "components"

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -18,6 +18,7 @@
     QDrawer,
   } from "$lib";
   import { isRouteActive } from "$lib/composables/use-router-link";
+  import { fade } from "svelte/transition";
 
   const components = [
     {
@@ -115,12 +116,12 @@
       to: "/utils/quaff",
     },
   ];
-  let contentEl: HTMLDivElement | null = null;
+  let contentEl: HTMLDivElement;
 
-  let selectedRailbarItem: "components" | "utils" | null = isRouteActive(
-    $Quaff.router,
-    "/components"
-  )
+  $: console.log($Quaff.router.url.pathname);
+
+  let selectedRailbarItem: "components" | "utils" | null;
+  $: selectedRailbarItem = isRouteActive($Quaff.router, "/components")
     ? "components"
     : isRouteActive($Quaff.router, "/utils")
     ? "utils"
@@ -156,46 +157,54 @@
         icon={$Quaff.dark.isActive ? "light_mode" : "dark_mode"}
         flat
         round
-        on:click={() => $Quaff.dark.toggle()}
+        on:click={$Quaff.dark.toggle}
       />
       <QBtn icon="help" flat />
     </QToolbar>
     <QRailbar slot="railbarLeft" class="surface no-round" bordered>
       <QList>
-        <QItem to="/" on:click={() => (selectedRailbarItem = null)}>
+        <QItem to="/">
           <QIcon name="home" />
           <QItemSection>Home</QItemSection>
         </QItem>
-        <QItem to="/components" on:click={() => (selectedRailbarItem = "components")}>
+        <QItem to="/components">
           <QIcon name="grid_view" />
           <QItemSection>Components</QItemSection>
         </QItem>
-        <QItem to="/grid" on:click={() => (selectedRailbarItem = null)}>
+        <QItem to="/grid">
           <QIcon name="grid_on" />
           <QItemSection>Grid</QItemSection>
         </QItem>
-        <QItem to="/utils" on:click={() => (selectedRailbarItem = "utils")}>
+        <QItem to="/utils">
           <QIcon name="construction" />
           <QItemSection>Quaff utils</QItemSection>
         </QItem>
-        <QItem to="/dev" on:click={() => (selectedRailbarItem = null)}>
+        <QItem to="/dev">
           <QIcon name="code" />
           <QItemSection>Dev tests</QItemSection>
         </QItem>
-        <QItem to="/layout" on:click={() => (selectedRailbarItem = null)}>
+        <QItem to="/layout">
           <QIcon name="dashboard_customize" />
           <QItemSection>Layout tests</QItemSection>
         </QItem>
       </QList>
     </QRailbar>
     <QDrawer slot="drawerLeft" persistent value={showDrawer}>
-      <QList dense>
-        {#each drawerContent as { name, to }}
-          <QItem {to} on:click={() => contentEl?.scrollTo({ top: 0, behavior: "smooth" })}
-            >{name}</QItem
-          >
-        {/each}
-      </QList>
+      {#key drawerContent}
+        <div in:fade={{ delay: 200, duration: 200 }} out:fade={{ duration: 200 }}>
+          <QList dense>
+            {#each drawerContent as { name, to }}
+              <QItem
+                {to}
+                on:click={() => contentEl.scrollTo({ top: 0, behavior: "smooth" })}
+                activeClass="primary-text"
+              >
+                {name}
+              </QItem>
+            {/each}
+          </QList>
+        </div>
+      {/key}
     </QDrawer>
     <div bind:this={contentEl} slot="content">
       <slot />

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -177,12 +177,12 @@
     </div>
   </QCard>
   <QCard title="Buttons">
-    <QBtn class="q-ma-sm" icon="favorite" label="Using Label" />
+    <QBtn class="q-ma-sm" icon="favorite" label="Using Label" on:activated={console.log} />
     <QBtn class="q-ma-sm">
       <span>Using</span><span style="color: blue">slot</span>
     </QBtn>
     <QBtn class="q-ma-sm" label="loading" loading />
-    <QBtn class="q-ma-sm" icon="add" label="Disabled" disable />
+    <QBtn class="q-ma-sm" icon="add" label="Disabled" disable on:activated={console.log} />
     <QBtn class="q-ma-sm" label="Unelevated" unelevated />
     <QBtn class="q-ma-sm" label="Outline" outline />
     <QBtn class="q-ma-sm" label="Rectangle" rectangle />
@@ -416,14 +416,14 @@
           content="Click on me!"
           responsive
           icon="img:/cocktail.jpg"
-          on:click={() => alert("OMG, you actually did it")}
+          on:activated={() => alert("OMG, you actually did it")}
         />
         <QChip
           content="Can't click on me, now!"
           responsive
           disable
           icon="img:/cocktail.jpg"
-          on:click={() => alert("OMG, you actually did it")}
+          on:activated={() => alert("OMG, you actually did it")}
         />
       </div>
     </QCardSection>

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -177,12 +177,23 @@
     </div>
   </QCard>
   <QCard title="Buttons">
-    <QBtn class="q-ma-sm" icon="favorite" label="Using Label" on:activated={console.log} />
+    <QBtn
+      class="q-ma-sm"
+      icon="favorite"
+      label="Using Label"
+      on:activated={() => alert("Hey you clicked")}
+    />
     <QBtn class="q-ma-sm">
       <span>Using</span><span style="color: blue">slot</span>
     </QBtn>
     <QBtn class="q-ma-sm" label="loading" loading />
-    <QBtn class="q-ma-sm" icon="add" label="Disabled" disable on:activated={console.log} />
+    <QBtn
+      class="q-ma-sm"
+      icon="add"
+      label="Disabled"
+      disable
+      on:activated={() => alert("Hey you clicked")}
+    />
     <QBtn class="q-ma-sm" label="Unelevated" unelevated />
     <QBtn class="q-ma-sm" label="Outline" outline />
     <QBtn class="q-ma-sm" label="Rectangle" rectangle />


### PR DESCRIPTION
- Fixed a bug where the left drawer in main +layout.svelte didn't open in certain cases
- Added a fade transition when the layout drawer changes (e.g. whe you go from /components to /utils using left railbar)
- Previous point needed a change to layout styles
- Added a new action that allows to listen for click, enter key and space key to be used in several components like QBtn, QChip for example. It takes into account the disabled state of the component
- Refactored QBtn and QChip to use this action