### PR TITLE
Btn and chip activated event fix

### DIFF
--- a/src/lib/components/button/QBtn.svelte
+++ b/src/lib/components/button/QBtn.svelte
@@ -19,7 +19,7 @@
     userClasses: QBtnProps["userClasses"] = undefined;
   export { userClasses as class };
 
-  const emit = createEventDispatcher();
+  const emit = createEventDispatcher<{ activated: MouseEvent | KeyboardEvent }>();
 
   let tag: "a" | "div";
   $: tag = to !== undefined ? "a" : "div";

--- a/src/lib/components/codeBlock/QCodeBlock.svelte
+++ b/src/lib/components/codeBlock/QCodeBlock.svelte
@@ -52,7 +52,7 @@
         size="sm"
         icon="content_copy"
         outline
-        on:click={copyCode}
+        on:activated={copyCode}
       >
         {btnContent}
       </QBtn>

--- a/src/lib/components/dialog/QDialog.svelte
+++ b/src/lib/components/dialog/QDialog.svelte
@@ -48,7 +48,7 @@
       value = true;
     }
   }
-  export function toggle(e: MouseEvent) {
+  export function toggle(e: CustomEvent<MouseEvent | KeyboardEvent>) {
     value = !value;
     e.stopPropagation();
   }
@@ -82,7 +82,7 @@
 </script>
 
 {#if noBtn === false}
-  <QBtn {...btnAttrs} on:click={toggle} on:click={(event) => emit("btnClick", event)}>
+  <QBtn {...btnAttrs} on:activated={toggle} on:activated={(event) => emit("btnClick", event)}>
     <slot name="button">
       {btnContent || ""}
     </slot>

--- a/src/lib/components/dialog/QDialog.svelte
+++ b/src/lib/components/dialog/QDialog.svelte
@@ -82,7 +82,7 @@
 </script>
 
 {#if noBtn === false}
-  <QBtn {...btnAttrs} on:activated={toggle} on:activated={(event) => emit("btnClick", event)}>
+  <QBtn {...btnAttrs} on:activated={toggle} on:activated={(event) => emit("btnActivated", event)}>
     <slot name="button">
       {btnContent || ""}
     </slot>

--- a/src/lib/components/drawer/QDrawer.svelte
+++ b/src/lib/components/drawer/QDrawer.svelte
@@ -33,7 +33,7 @@
 
   $: hideOnRouteChange = persistent !== true || overlay === true;
 
-  export const show = (e?: MouseEvent) => {
+  export const show = (e?: CustomEvent<MouseEvent | KeyboardEvent>) => {
     if (value !== true) {
       value = true;
       e && e.stopPropagation();
@@ -46,7 +46,7 @@
     }
   };
 
-  export const toggle = (e?: MouseEvent) => {
+  export const toggle = (e?: CustomEvent<MouseEvent | KeyboardEvent>) => {
     value = !value;
     e && e.stopPropagation();
   };

--- a/src/lib/components/private/QDocsSection.svelte
+++ b/src/lib/components/private/QDocsSection.svelte
@@ -15,7 +15,7 @@
         class="snippet-dialog"
         bind:value={dialog}
         btnAttrs={{ outline: true, icon: "code", class: "circle" }}
-        on:btnClick={() => (dialog = true)}
+        on:btnActivated={() => (dialog = true)}
         modal
       >
         <QCodeBlock code={snippets[title]} language="svelte" {title} copiable />

--- a/src/lib/components/table/QTable.svelte
+++ b/src/lib/components/table/QTable.svelte
@@ -166,14 +166,14 @@
       size="sm"
       flat
       disable={page === 1}
-      on:click={() => (page = page - 1)}
+      on:activated={() => (page = page - 1)}
     />
     <QBtn
       icon="chevron_right"
       size="sm"
       flat
       disable={page * rowsPerPage >= rows.length}
-      on:click={() => (page = page + 1)}
+      on:activated={() => (page = page + 1)}
     />
   </div>
 </div>

--- a/src/lib/helpers/activationHandler.ts
+++ b/src/lib/helpers/activationHandler.ts
@@ -1,11 +1,10 @@
-type Event = MouseEvent | KeyboardEvent;
 interface Options {
   disable: boolean | undefined;
-  callback: (e: Event) => void;
+  callback: (e: MouseEvent | KeyboardEvent) => void;
 }
 
 export function activationHandler(node: HTMLElement, { disable, callback }: Options) {
-  function handleEvent(event: Event) {
+  function handleEvent(event: MouseEvent | KeyboardEvent) {
     if (disable) {
       event.preventDefault();
       event.stopPropagation();

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -155,7 +155,7 @@
         icon={$Quaff.dark.isActive ? "light_mode" : "dark_mode"}
         flat
         round
-        on:click={$Quaff.dark.toggle}
+        on:activated={$Quaff.dark.toggle}
       />
       <QBtn icon="help" flat />
     </QToolbar>

--- a/src/routes/components/chip/+page.svelte
+++ b/src/routes/components/chip/+page.svelte
@@ -55,8 +55,8 @@
 
     <QDocsSection {snippets} title="Chips with Custom Tabindex">
       <div class="flex q-gap-lg middle-align">
-        <QChip tabindex="2" content="Tabindex 2 Chip" />
-        <QChip tabindex="3" content="Tabindex 3 Chip" />
+        <QChip tabindex={2} content="Tabindex 2 Chip" />
+        <QChip tabindex={3} content="Tabindex 3 Chip" />
       </div>
     </QDocsSection>
   </div>

--- a/src/routes/components/dialog/+page.svelte
+++ b/src/routes/components/dialog/+page.svelte
@@ -7,55 +7,28 @@
   import DialogContent from "./DialogContent.svelte";
   import snippets from "./docs.snippets";
 
-  interface Dialog {
-    el: QDialog | null;
-    value: boolean;
-  }
-
-  let exampleDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    topDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    defaultDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    rightDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    bottomDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    leftDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    modalDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    persistentDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    fullscreenDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    methodsDialog: Dialog = {
-      el: null,
-      value: false,
-    },
-    btnAttrsDialog: Dialog = {
-      el: null,
-      value: false,
-    };
+  let exampleDialog = false,
+    exampleDialogEl: QDialog,
+    topDialog = false,
+    topDialogEl: QDialog,
+    defaultDialog = false,
+    defaultDialogEl: QDialog,
+    rightDialog = false,
+    rightDialogEl: QDialog,
+    bottomDialog = false,
+    bottomDialogEl: QDialog,
+    leftDialog = false,
+    leftDialogEl: QDialog,
+    modalDialog = false,
+    modalDialogEl: QDialog,
+    persistentDialog = false,
+    persistentDialogEl: QDialog,
+    fullscreenDialog = false,
+    fullscreenDialogEl: QDialog,
+    methodsDialog = false,
+    methodsDialogEl: QDialog,
+    btnAttrsDialog = false,
+    btnAttrsDialogEl;
 </script>
 
 <QDocs QComponentDocs={QDialogDocs}>
@@ -64,91 +37,81 @@
     btnContent="Open cookie settings"
     modal
     persistent
-    bind:value={exampleDialog.value}
-    bind:this={exampleDialog.el}
+    bind:value={exampleDialog}
+    bind:this={exampleDialogEl}
   >
-    <DialogContent dialogEl={exampleDialog.el} />
+    <DialogContent dialogEl={exampleDialogEl} />
   </QDialog>
 
   <div slot="usage">
     <QDocsSection {snippets} title="Positions">
-      <QDialog bind:this={defaultDialog.el} bind:value={defaultDialog.value} btnContent="Default">
-        <DialogContent dialogEl={defaultDialog.el} />
+      <QDialog bind:this={defaultDialogEl} bind:value={defaultDialog} btnContent="Default">
+        <DialogContent dialogEl={defaultDialogEl} />
+      </QDialog>
+      <QDialog bind:this={topDialogEl} bind:value={topDialog} btnContent="Top" position="top">
+        <DialogContent dialogEl={topDialogEl} />
       </QDialog>
       <QDialog
-        bind:this={topDialog.el}
-        bind:value={topDialog.value}
-        btnContent="Top"
-        position="top"
-      >
-        <DialogContent dialogEl={topDialog.el} />
-      </QDialog>
-      <QDialog
-        bind:this={rightDialog.el}
-        bind:value={rightDialog.value}
+        bind:this={rightDialogEl}
+        bind:value={rightDialog}
         btnContent="Right"
         position="right"
       >
-        <DialogContent dialogEl={rightDialog.el} />
+        <DialogContent dialogEl={rightDialogEl} />
       </QDialog>
       <QDialog
-        bind:this={bottomDialog.el}
-        bind:value={bottomDialog.value}
+        bind:this={bottomDialogEl}
+        bind:value={bottomDialog}
         btnContent="Bottom"
         position="bottom"
       >
-        <DialogContent dialogEl={bottomDialog.el} />
+        <DialogContent dialogEl={bottomDialogEl} />
       </QDialog>
-      <QDialog
-        bind:this={leftDialog.el}
-        bind:value={leftDialog.value}
-        btnContent="Left"
-        position="left"
-      >
-        <DialogContent dialogEl={leftDialog.el} />
+      <QDialog bind:this={leftDialogEl} bind:value={leftDialog} btnContent="Left" position="left">
+        <DialogContent dialogEl={leftDialogEl} />
       </QDialog>
     </QDocsSection>
 
     <QDocsSection {snippets} title="Types">
-      <QDialog bind:this={modalDialog.el} bind:value={modalDialog.value} btnContent="Modal" modal>
-        <DialogContent dialogEl={modalDialog.el} />
+      <QDialog bind:this={modalDialogEl} bind:value={modalDialog} btnContent="Modal" modal>
+        <DialogContent dialogEl={modalDialogEl} />
       </QDialog>
       <QDialog
-        bind:this={fullscreenDialog.el}
-        bind:value={fullscreenDialog.value}
+        bind:this={fullscreenDialogEl}
+        bind:value={fullscreenDialog}
         btnContent="Fullscreen"
         fullscreen
       >
-        <DialogContent dialogEl={fullscreenDialog.el} />
+        <DialogContent dialogEl={fullscreenDialogEl} />
       </QDialog>
       <QDialog
-        bind:this={persistentDialog.el}
-        bind:value={persistentDialog.value}
+        bind:this={persistentDialogEl}
+        bind:value={persistentDialog}
         btnContent="Persistent"
         persistent
         modal
       >
-        <DialogContent dialogEl={persistentDialog.el} />
+        <DialogContent dialogEl={persistentDialogEl} />
       </QDialog>
     </QDocsSection>
 
     <QDocsSection {snippets} title="noBtn and programmatic toggle">
-      <QDialog bind:this={methodsDialog.el} bind:value={methodsDialog.value} noBtn persistent>
-        <DialogContent dialogEl={methodsDialog.el} />
+      <QDialog bind:this={methodsDialogEl} bind:value={methodsDialog} noBtn persistent>
+        <DialogContent dialogEl={methodsDialogEl} />
       </QDialog>
-      <QBtn on:activated={methodsDialog.el?.show}>Show</QBtn>
-      <QBtn on:activated={methodsDialog.el?.hide}>Hide</QBtn>
-      <QBtn on:activated={methodsDialog.el?.toggle}>Toggle</QBtn>
+      <QBtn on:activated={methodsDialogEl.show}>Show</QBtn>
+      <QBtn on:activated={methodsDialogEl.hide}>Hide</QBtn>
+      <QBtn on:activated={methodsDialogEl.toggle}>Toggle</QBtn>
     </QDocsSection>
 
     <QDocsSection {snippets} title="Custom button attributes">
       <QDialog
-        bind:this={btnAttrsDialog.el}
-        bind:value={btnAttrsDialog.value}
+        bind:this={btnAttrsDialogEl}
+        bind:value={btnAttrsDialog}
         btnContent="Custom button styles"
         btnAttrs={{ icon: "star", rectangle: true, outline: true }}
       >
-        <DialogContent dialogEl={btnAttrsDialog.el} />
+        <DialogContent dialogEl={btnAttrsDialogEl} />
       </QDialog>
     </QDocsSection>
   </div>

--- a/src/routes/components/dialog/+page.svelte
+++ b/src/routes/components/dialog/+page.svelte
@@ -136,9 +136,9 @@
       <QDialog bind:this={methodsDialog.el} bind:value={methodsDialog.value} noBtn persistent>
         <DialogContent dialogEl={methodsDialog.el} />
       </QDialog>
-      <QBtn on:click={() => methodsDialog.el?.show()}>Show</QBtn>
-      <QBtn on:click={() => methodsDialog.el?.hide()}>Hide</QBtn>
-      <QBtn on:click={() => methodsDialog.el?.toggle()}>Toggle</QBtn>
+      <QBtn on:activated={methodsDialog.el?.show}>Show</QBtn>
+      <QBtn on:activated={methodsDialog.el?.hide}>Hide</QBtn>
+      <QBtn on:activated={methodsDialog.el?.toggle}>Toggle</QBtn>
     </QDocsSection>
 
     <QDocsSection {snippets} title="Custom button attributes">

--- a/src/routes/components/dialog/DialogContent.svelte
+++ b/src/routes/components/dialog/DialogContent.svelte
@@ -28,7 +28,7 @@
     </div>
   </QCardSection>
   <QCardActions align="right">
-    <QBtn on:click={() => dialogEl?.hide()}>Cancel</QBtn>
-    <QBtn on:click={() => dialogEl?.hide()} disable={!exampleCheckbox}>Save</QBtn>
+    <QBtn on:activated={dialogEl?.hide}>Cancel</QBtn>
+    <QBtn on:activated={dialogEl?.hide} disable={!exampleCheckbox}>Save</QBtn>
   </QCardActions>
 </QCard>

--- a/src/routes/components/layout/+page.svelte
+++ b/src/routes/components/layout/+page.svelte
@@ -62,7 +62,7 @@
 <QDocs QComponentDocs={QLayoutDocs}>
   <QLayout slot="display" view="lhh lpr lfr" headerHeight="50px" footerHeight="50px">
     <QToolbar slot="header" class="surface small-elevate no-round">
-      <QBtn icon="menu" flat on:click={displayLeftDrawerElement.toggle} />
+      <QBtn icon="menu" flat on:activated={displayLeftDrawerElement.toggle} />
       <h3 class="small max center-align">Header</h3>
     </QToolbar>
     <QDrawer
@@ -119,7 +119,7 @@
             class="small-elevate"
           >
             {#if leftDrawer}
-              <QBtn icon="menu" flat on:click={leftDrawerElement.toggle} />
+              <QBtn icon="menu" flat on:activated={leftDrawerElement.toggle} />
             {/if}
             <div class="flex column">
               <QRadio bind:selected={viewArr[0][0]} value="h" label="h" />
@@ -145,7 +145,7 @@
               <QRadio class="no-margin" bind:selected={viewArr[0][2]} value="r" label="r" />
             </div>
             {#if rightDrawer}
-              <QBtn icon="menu" flat on:click={rightDrawerElement.toggle} />
+              <QBtn icon="menu" flat on:activated={rightDrawerElement.toggle} />
             {/if}
           </QToolbar>
 
@@ -253,7 +253,7 @@
 
           <QFooter style={footer ? undefined : "display: none;"} slot="footer">
             {#if leftDrawer}
-              <QBtn icon="menu" flat on:click={leftDrawerElement.toggle} />
+              <QBtn icon="menu" flat on:activated={leftDrawerElement.toggle} />
             {/if}
             <div class="flex column">
               <QRadio bind:selected={viewArr[2][0]} value="f" label="f" />
@@ -279,7 +279,7 @@
               <QRadio class="no-margin" bind:selected={viewArr[2][2]} value="r" label="r" />
             </div>
             {#if rightDrawer}
-              <QBtn icon="menu" flat on:click={rightDrawerElement.toggle} />
+              <QBtn icon="menu" flat on:activated={rightDrawerElement.toggle} />
             {/if}
           </QFooter>
 

--- a/src/routes/layout/+page.svelte
+++ b/src/routes/layout/+page.svelte
@@ -12,19 +12,19 @@
     QFooter,
   } from "$lib";
 
-  let leftDrawer: QDrawer | null = null;
-  let rightDrawer: QDrawer | null = null;
+  let leftDrawer: QDrawer;
+  let rightDrawer: QDrawer;
 </script>
 
 <QLayout view="hHh LpR fFr" leftRailbarWidth="120">
   <QToolbar slot="header" class="primary-container">
-    <QBtn icon="menu" flat on:click={() => leftDrawer?.toggle()} />
+    <QBtn icon="menu" flat on:activated={leftDrawer.toggle} />
     <h5 class="max center-align">
       <a href="/">Go home</a>
     </h5>
     <QBtn flat icon="attach_file" />
     <QBtn flat icon="today" />
-    <QBtn icon="menu" flat on:click={() => rightDrawer?.toggle()} />
+    <QBtn icon="menu" flat on:activated={rightDrawer.toggle} />
   </QToolbar>
   <QRailbar slot="railbarLeft" bordered width="120">
     <QList>


### PR DESCRIPTION
- Changed all occurrences of `on:click` to `on:activated` where QBtn are used
- Small fix for typescript: changed tabindexes of QChip instances to be a number