### PR TITLE
Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 .vscode
 .vscode/*
+
+src/lib/helpers/version.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,9 +9,9 @@
       "version": "0.1.0-prealpha4",
       "dependencies": {
         "beercss": "^3.2.13",
+        "highlight.js": "^11.8.0",
         "material-dynamic-colors": "^1.0.1",
-        "prism-svelte": "0.5.0",
-        "prismjs": "^1.29.0"
+        "svelte-highlight": "^7.3.0"
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^2.1.0",
@@ -2243,6 +2243,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/highlight.js": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -3118,19 +3126,6 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
-    "node_modules/prism-svelte": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/prism-svelte/-/prism-svelte-0.5.0.tgz",
-      "integrity": "sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA=="
-    },
-    "node_modules/prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/publint": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/publint/-/publint-0.2.0.tgz",
@@ -3610,6 +3605,14 @@
         "svelte": {
           "optional": true
         }
+      }
+    },
+    "node_modules/svelte-highlight": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/svelte-highlight/-/svelte-highlight-7.3.0.tgz",
+      "integrity": "sha512-59oE9/xOFXAdT97qXIt6HMlzL2f+0YNQ+BArzRONwCW96ElxX7TGme1kU5s3tsk1D88G5dhBixcP1chOGOkVsg==",
+      "dependencies": {
+        "highlight.js": "11.8.0"
       }
     },
     "node_modules/svelte-hmr": {
@@ -5715,6 +5718,11 @@
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
       "dev": true
     },
+    "highlight.js": {
+      "version": "11.8.0",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.8.0.tgz",
+      "integrity": "sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg=="
+    },
     "ignore": {
       "version": "5.2.4",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.2.4.tgz",
@@ -6346,16 +6354,6 @@
         }
       }
     },
-    "prism-svelte": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/prism-svelte/-/prism-svelte-0.5.0.tgz",
-      "integrity": "sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA=="
-    },
-    "prismjs": {
-      "version": "1.29.0",
-      "resolved": "https://registry.npmjs.org/prismjs/-/prismjs-1.29.0.tgz",
-      "integrity": "sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q=="
-    },
     "publint": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/publint/-/publint-0.2.0.tgz",
@@ -6695,6 +6693,14 @@
         "espree": "^9.0.0",
         "postcss": "^8.4.25",
         "postcss-scss": "^4.0.6"
+      }
+    },
+    "svelte-highlight": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/svelte-highlight/-/svelte-highlight-7.3.0.tgz",
+      "integrity": "sha512-59oE9/xOFXAdT97qXIt6HMlzL2f+0YNQ+BArzRONwCW96ElxX7TGme1kU5s3tsk1D88G5dhBixcP1chOGOkVsg==",
+      "requires": {
+        "highlight.js": "11.8.0"
       }
     },
     "svelte-hmr": {

--- a/package.json
+++ b/package.json
@@ -59,8 +59,8 @@
   "type": "module",
   "dependencies": {
     "beercss": "^3.2.13",
+    "highlight.js": "^11.8.0",
     "material-dynamic-colors": "^1.0.1",
-    "prism-svelte": "0.5.0",
-    "prismjs": "^1.29.0"
+    "svelte-highlight": "^7.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,15 +8,15 @@ dependencies:
   beercss:
     specifier: ^3.2.13
     version: 3.2.13
+  highlight.js:
+    specifier: ^11.8.0
+    version: 11.8.0
   material-dynamic-colors:
     specifier: ^1.0.1
     version: 1.0.1
-  prism-svelte:
-    specifier: 0.5.0
-    version: 0.5.0
-  prismjs:
-    specifier: ^1.29.0
-    version: 1.29.0
+  svelte-highlight:
+    specifier: ^7.3.0
+    version: 7.3.0
 
 devDependencies:
   '@sveltejs/adapter-auto':
@@ -1550,6 +1550,11 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
+  /highlight.js@11.8.0:
+    resolution: {integrity: sha512-MedQhoqVdr0U6SSnWPzfiadUcDHfN/Wzq25AkXiQv9oiOO/sG0S7XkvpFIqWBl9Yq1UYyYOOVORs5UW2XlPyzg==}
+    engines: {node: '>=12.0.0'}
+    dev: false
+
   /ignore-walk@5.0.1:
     resolution: {integrity: sha512-yemi4pMf51WKT7khInJqAvsIGzoqYXblnsz0ql8tM+yi1EKYTY1evX4NAbJrLL/Aanr2HyZeluqU+Oi7MGHokw==}
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
@@ -2062,15 +2067,6 @@ packages:
       react-is: 18.2.0
     dev: true
 
-  /prism-svelte@0.5.0:
-    resolution: {integrity: sha512-db91Bf3pRGKDPz1lAqLFSJXeW13mulUJxhycysFpfXV5MIK7RgWWK2E5aPAa71s8TCzQUXxF5JOV42/iOs6QkA==}
-    dev: false
-
-  /prismjs@1.29.0:
-    resolution: {integrity: sha512-Kx/1w86q/epKcmte75LNrEoT+lX8pBpavuAbvJWRXar7Hz8jrtF+e3vY751p0R8H9HdArwaCTNDDzHg/ScJK1Q==}
-    engines: {node: '>=6'}
-    dev: false
-
   /publint@0.2.0:
     resolution: {integrity: sha512-h8lxdjhQjpDw+A4BgY4sE7Z4CU3x5tCGGpERVdKGDQmWMtr1P7kvptJS2P10HhmNnS7Yeny37zfQE5+xRZ6nig==}
     engines: {node: '>=16'}
@@ -2309,6 +2305,12 @@ packages:
       postcss-scss: 4.0.6(postcss@8.4.27)
       svelte: 4.1.2
     dev: true
+
+  /svelte-highlight@7.3.0:
+    resolution: {integrity: sha512-59oE9/xOFXAdT97qXIt6HMlzL2f+0YNQ+BArzRONwCW96ElxX7TGme1kU5s3tsk1D88G5dhBixcP1chOGOkVsg==}
+    dependencies:
+      highlight.js: 11.8.0
+    dev: false
 
   /svelte-hmr@0.15.2(svelte@4.1.2):
     resolution: {integrity: sha512-q/bAruCvFLwvNbeE1x3n37TYFb3mTBJ6TrCq6p2CoFbSTNhDE9oAtEfpy+wmc9So8AG0Tja+X0/mJzX9tSfvIg==}

--- a/src/dev/version-plugin.ts
+++ b/src/dev/version-plugin.ts
@@ -1,0 +1,21 @@
+import { readFile, writeFile } from "fs/promises";
+import path from "path";
+import type { Plugin } from "vite";
+
+function versionPlugin(): Plugin {
+  return {
+    name: "version-plugin",
+    async configResolved(config) {
+      const data = await readFile(path.resolve(process.cwd(), "package.json"), "utf-8");
+      const { version } = JSON.parse(data);
+      const content = `export default "${version}";\n`;
+
+      return await writeFile(
+        path.resolve(process.cwd(), config.root, "src/lib/helpers/version.ts"),
+        content
+      );
+    },
+  };
+}
+
+export default versionPlugin;

--- a/src/lib/components/codeBlock/QCodeBlock.svelte
+++ b/src/lib/components/codeBlock/QCodeBlock.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import Prism from "prismjs";
-  import "prismjs/themes/prism-twilight.css";
-  import "prismjs/components/prism-typescript";
-  import "prism-svelte";
-  import type { QCodeBlockProps } from "./props";
+  import Highlight from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import "svelte-highlight/styles/material.css";
   import { QBtn } from "$lib";
+  import type { QCodeBlockProps } from "./props";
 
   export let language: QCodeBlockProps["language"],
     code: QCodeBlockProps["code"] = "/* No code found */",
@@ -13,8 +12,6 @@
 
   let btnContent = "Copy";
   let btnColor = "primary";
-
-  $: highlighted = Prism.highlight(code!, Prism.languages[language], language);
 
   async function copyCode() {
     try {
@@ -45,8 +42,10 @@
 
 <div class="q-code-block">
   {#if copiable}
-    <div class="flex between-align middle-align q-pb-sm">
-      <h4 class="q-ma-none q-pr-lg">{title}</h4>
+    <div class="flex between-align {title ? 'middle' : 'right'}-align q-pb-sm">
+      {#if title}
+        <h4 class="q-ma-none q-pr-lg">{title}</h4>
+      {/if}
       <QBtn
         class="{btnColor}-border {btnColor}-text"
         size="sm"
@@ -60,7 +59,7 @@
   {:else if title}
     <h4>{title}</h4>
   {/if}
-  <pre class="language-svelte"><code>{@html highlighted}</code></pre>
+  <Highlight language={typescript} {code} />
 </div>
 
 <style>

--- a/src/lib/global.d.ts
+++ b/src/lib/global.d.ts
@@ -1,4 +1,3 @@
-declare var __QUAFF_VERSION__: string;
 declare var __PLATFORM__:
   | "aix"
   | "darwin"

--- a/src/lib/stores/Quaff.ts
+++ b/src/lib/stores/Quaff.ts
@@ -1,9 +1,10 @@
 import { writable, derived } from "svelte/store";
 import { page } from "$app/stores";
+import version from "$lib/helpers/version";
 
 function quaff() {
   const { subscribe, set, update } = writable({
-    version: __QUAFF_VERSION__,
+    version,
     dark: false,
     //TODO lang: {},
     //TODO? iconSet: {},

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -138,13 +138,6 @@
   if (data.isDark) $Quaff.dark.set(true);
 </script>
 
-<svelte:head>
-  <link
-    href="https://cdn.jsdelivr.net/npm/prism-themes@1.4.0/themes/prism-material-dark.css"
-    rel="stylesheet"
-  />
-</svelte:head>
-
 {#if $Quaff.router.route.id === "/layout"}
   <slot />
 {:else}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,15 +1,10 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vitest/config";
+import versionPlugin from "./src/dev/version-plugin";
 import path from "path";
-import { readFileSync } from "fs";
-import { fileURLToPath } from "url";
-
-const file = fileURLToPath(new URL("package.json", import.meta.url));
-const json = readFileSync(file, "utf8");
-const pkg = JSON.parse(json);
 
 export default defineConfig({
-  plugins: [sveltekit()],
+  plugins: [versionPlugin(), sveltekit()],
   test: {
     include: ["src/**/*.{test,spec}.{js,ts}"],
   },
@@ -23,8 +18,5 @@ export default defineConfig({
       $stores: path.resolve(__dirname, "./src/lib/stores"),
       $helpers: path.resolve(__dirname, "./src/lib/helpers"),
     },
-  },
-  define: {
-    __QUAFF_VERSION__: JSON.stringify(pkg.version),
   },
 });


### PR DESCRIPTION
Regarding the `version`, it might be a bit over engineered to have a custom Vite plugin, but I couldn't get the `package.json` import to work (directory structure gets changed on build) and the previous solution didn't work either.
PrismJS caused several issues, especially the auto replacement of html contents which couldn't be disabled, causing buggy behavior (I tried `Prism.manual = true`, to no avail), that's why it was replaced by `svelte-highlight`.