### PR TITLE
Qtooltip refactor

### DIFF
--- a/src/lib/components/tooltip/QTooltip.svelte
+++ b/src/lib/components/tooltip/QTooltip.svelte
@@ -7,6 +7,14 @@
   export { userClasses as class };
 </script>
 
-<div class="q-tooltip {position} {userClasses}" class:q-tooltip--active={value} {...$$restProps}>
+<div
+  class="q-tooltip {userClasses}"
+  class:q-tooltip--top={position === "top"}
+  class:q-tooltip--right={position === "right"}
+  class:q-tooltip--bottom={position === "bottom"}
+  class:q-tooltip--left={position === "left"}
+  class:q-tooltip--active={value}
+  {...$$restProps}
+>
   <slot />
 </div>

--- a/src/lib/components/tooltip/index.scss
+++ b/src/lib/components/tooltip/index.scss
@@ -4,6 +4,7 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  cursor: auto;
   gap: 0.5rem;
   background-color: var(--inverse-surface);
   color: var(--inverse-on-surface);

--- a/src/lib/css/ripple.scss
+++ b/src/lib/css/ripple.scss
@@ -16,8 +16,15 @@
   }
 
   &--effect {
-    position: relative;
+    position: absolute;
+    left: 0;
+    right: 0;
+    top: 0;
+    bottom: 0;
     overflow: hidden;
+    background: none;
+    pointer-events: none;
+    z-index: 999;
   }
 }
 

--- a/src/lib/helpers/ripple.ts
+++ b/src/lib/helpers/ripple.ts
@@ -9,18 +9,24 @@ const triggerEvents = ["pointerdown", "touchstart", "keydown"] as const;
 const cancelEvents = ["mouseleave", "dragleave", "touchmove", "touchcancel", "pointerup", "keyup"];
 
 export function ripple(el: HTMLElement, options: RippleOptions = {}) {
+  const rippleContainer = document.createElement("div");
+
+  addClasses();
+  setOptions(options);
+  el.appendChild(rippleContainer);
+
   function addClasses(center?: boolean) {
     let shouldBeCentered = center || options.center;
 
-    if (!el.classList.contains("q-ripple--effect")) {
-      el.classList.add("q-ripple--effect");
+    if (!rippleContainer.classList.contains("q-ripple--effect")) {
+      rippleContainer.classList.add("q-ripple--effect");
     }
 
-    if (!shouldBeCentered && el.classList.contains("q-ripple--center")) {
-      el.classList.remove("q-ripple--center");
+    if (!shouldBeCentered && rippleContainer.classList.contains("q-ripple--center")) {
+      rippleContainer.classList.remove("q-ripple--center");
     }
 
-    shouldBeCentered && el.classList.add("q-ripple--center");
+    shouldBeCentered && rippleContainer.classList.add("q-ripple--center");
   }
 
   function setOptions(options: RippleOptions) {
@@ -29,16 +35,13 @@ export function ripple(el: HTMLElement, options: RippleOptions = {}) {
     }
 
     if (options.color) {
-      el.style.setProperty("--ripple-color", options.color);
+      rippleContainer.style.setProperty("--ripple-color", options.color);
     }
 
     if (options.duration) {
-      el.style.setProperty("--ripple-duration", `${options.duration}ms`);
+      rippleContainer.style.setProperty("--ripple-duration", `${options.duration}ms`);
     }
   }
-
-  addClasses();
-  setOptions(options);
 
   function createRipple(e: PointerEvent | KeyboardEvent | TouchEvent, center?: boolean) {
     if (options.disable || el.hasAttribute("aria-disabled")) return;
@@ -79,7 +82,7 @@ export function ripple(el: HTMLElement, options: RippleOptions = {}) {
     ripple.style.top = `${clientY - rect.top - radius}px`;
     ripple.style.width = ripple.style.height = `${radius * 2}px`;
 
-    el.appendChild(ripple);
+    rippleContainer.appendChild(ripple);
 
     function removeRipple() {
       if (ripple === null) return;

--- a/src/routes/dev/+page.svelte
+++ b/src/routes/dev/+page.svelte
@@ -449,7 +449,11 @@
           <div class="flex justify-between" style="align-items: center">
             <QBtn label="I'm rich">
               <QTooltip position="right" class="q-pa-none">
-                <QCard title="Wow this is a card" class="primary-container no-round">
+                <QCard
+                  title="Wow this is a card"
+                  class="primary-container"
+                  style="border-radius: inherit"
+                >
                   <QCardSection class="items-center">
                     <QIcon name="help" class="q-mr-md" />
                     I'm inside the tooltip


### PR DESCRIPTION
Refactored ripple so it doesn't interfere with QTooltip. Also refactored QTooltip to use dynamic classes and fixed cursor.
There's still a "problem" of text not being selectable inside the tooltip but it's maybe better like this, buttons still seem to be clickable.