### PR TITLE
fix(docs.snippets.ts): remove two needless files.

### DIFF
--- a/src/routes/dev/docs.snippets.ts
+++ b/src/routes/dev/docs.snippets.ts
@@ -1,4 +1,0 @@
-// AUTO GENERATED FILE - DO NOT MODIFY OR DELETE
-// @quaffHash 4f53cda18c2baa0c0354bb5f9a3ecbe5
-
-export default {};

--- a/src/routes/layout/docs.snippets.ts
+++ b/src/routes/layout/docs.snippets.ts
@@ -1,4 +1,0 @@
-// AUTO GENERATED FILE - DO NOT MODIFY OR DELETE
-// @quaffHash 4f53cda18c2baa0c0354bb5f9a3ecbe5
-
-export default {};


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [x] Other, please describe: Removed needless files, see `What's new?`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

This deletes two files that don't seem to contain any useful content, are not regenerated by `docgen-snippets` and only exist since a few recent commits:

https://github.com/quaffui/quaff/commits/main/src/routes/dev/docs.snippets.ts
https://github.com/quaffui/quaff/commits/main/src/routes/layout/docs.snippets.ts


## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
