### PR TITLE
Docgen fixes

### DIFF
--- a/docgen/snippets/getSnippetPagePaths.ts
+++ b/docgen/snippets/getSnippetPagePaths.ts
@@ -1,0 +1,19 @@
+import path from "path";
+import { fileURLToPath } from "url";
+import getComponentDirs from "../helpers/getComponentDirs.js";
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+const rootDir = path.resolve(dirname, "../../src/routes/components");
+
+export default async function getSnippetPagePaths() {
+  const componentsToIgnore = ["layout"];
+
+  const componentDirs = (await getComponentDirs(rootDir)).filter(
+    (dir) => !componentsToIgnore.includes(dir)
+  );
+
+  return componentDirs.map((dir) => {
+    const dirPath = path.resolve(rootDir, dir);
+    return path.resolve(dirPath, "+page.svelte");
+  });
+}

--- a/docgen/snippets/updateAllSnippets.ts
+++ b/docgen/snippets/updateAllSnippets.ts
@@ -1,21 +1,10 @@
-import path from "path";
-import { fileURLToPath } from "url";
-import getComponentDirs from "../helpers/getComponentDirs.js";
+import getSnippetPagePaths from "./getSnippetPagePaths.js";
 import updateSnippetsForPage from "./updateSnippetsForPage.js";
 
-const dirname = path.dirname(fileURLToPath(import.meta.url));
-const rootDir = path.resolve(dirname, "../../src/routes/components");
-
 export default async function updateAllSnippets() {
-  const componentsToIgnore = ["layout"];
+  const snippetPagePaths = await getSnippetPagePaths();
 
-  const componentDirs = (await getComponentDirs(rootDir)).filter(
-    (dir) => !componentsToIgnore.includes(dir)
-  );
-
-  for (const dir of componentDirs) {
-    const dirPath = path.resolve(rootDir, dir);
-    const pageFilePath = path.resolve(dirPath, "+page.svelte");
-    await updateSnippetsForPage(pageFilePath);
+  for (const snippetPagePath of snippetPagePaths) {
+    await updateSnippetsForPage(snippetPagePath);
   }
 }

--- a/src/routes/utils/quaff/docs.snippets.ts
+++ b/src/routes/utils/quaff/docs.snippets.ts
@@ -1,4 +1,0 @@
-// AUTO GENERATED FILE - DO NOT MODIFY OR DELETE
-// @quaffHash 4f53cda18c2baa0c0354bb5f9a3ecbe5
-
-export default {};


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- The Vite plugin now uses a similar logic to check the file paths of snippets to create as the `docgen-snippets` script. This should prevent the `layout` snippets from being overwritten and unneeded snippets from being created.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
