### PR TITLE
fix(docgen): allow starting without .svelte-kit dir.

### DIFF
--- a/src/dev/waitForSvelteKit.ts
+++ b/src/dev/waitForSvelteKit.ts
@@ -1,0 +1,63 @@
+import { watch } from "fs";
+import { dirname, resolve as resolvePath } from "path";
+
+type PromiseResolve = (value: void | PromiseLike<void>) => void;
+type PromiseWithResolve = Promise<void> & { resolve: PromiseResolve };
+
+function makeResolvablePromise() {
+  let resolvePromise: PromiseResolve = () => {};
+
+  const p = new Promise<void>((resolve) => {
+    resolvePromise = resolve;
+  });
+
+  return Object.assign(p, { resolve: resolvePromise }) as Omit<PromiseWithResolve, "resolve"> & {
+    resolve?: PromiseWithResolve["resolve"];
+  };
+}
+
+const TIMEOUT_MS = 30 * 1000;
+
+export default async function waitForSvelteKit({
+  svelteKitPathResolved,
+  svelteKitTsconfigPathResolved,
+}: {
+  svelteKitPathResolved: string;
+  svelteKitTsconfigPathResolved: string;
+}) {
+  const cancelWatcher = new AbortController();
+  const promise = makeResolvablePromise();
+
+  const timeout = setTimeout(() => {
+    console.warn("timeout reached. this is probably a bug.");
+    promise.resolve?.();
+  }, TIMEOUT_MS);
+
+  watch(
+    dirname(svelteKitPathResolved),
+    {
+      recursive: true,
+      signal: cancelWatcher.signal,
+    },
+    (eventType, fileName) => {
+      if (!fileName?.includes("tsconfig.json")) {
+        return;
+      }
+
+      const pathResolved = resolvePath(fileName);
+
+      if (pathResolved === svelteKitTsconfigPathResolved) {
+        cancelWatcher.abort();
+
+        if (!promise.resolve) {
+          throw new Error("expected promise to have a resolve property");
+        }
+
+        clearInterval(timeout);
+        promise.resolve();
+      }
+    }
+  );
+
+  return await promise;
+}


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- You can now delete `.svelte-kit/` and run `npm run dev` without docgen failing. Our Vite plugin now uses a file watcher to handle cases like this - but only when needed. While I wish there was an easier solution, I couldn't find one.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
