### PR TITLE
Snippets fix

### DIFF
--- a/docgen/props/getInfo.ts
+++ b/docgen/props/getInfo.ts
@@ -22,13 +22,13 @@ export default async function getInfo(
     return { needsToBeGenerated: false };
   }
 
-  const hashProps = await generateHash(await readFile(propsFilePath, "utf8"));
+  const hashProps = generateHash(await readFile(propsFilePath, "utf8"));
 
   if (!(await pathExists(docsPropsFilePath))) {
     return { needsToBeGenerated: true, hashProps };
   }
 
-  const hashFromDocsProps = await extractHash(await readFile(docsPropsFilePath, "utf8"));
+  const hashFromDocsProps = extractHash(await readFile(docsPropsFilePath, "utf8"));
   const needsToBeGenerated = hashProps !== hashFromDocsProps;
 
   return { needsToBeGenerated, hashProps };

--- a/docgen/props/parseInterface.ts
+++ b/docgen/props/parseInterface.ts
@@ -25,7 +25,7 @@ export interface ParsedProp extends ParsedPropBase {
 
 export interface ParsedSnippet extends ParsedPropBase {
   isSnippet: true;
-  type: SnippetType | SnippetType[];
+  type: SnippetType[];
 }
 
 export type ParsedPropOrSnippet = ParsedProp | ParsedSnippet;
@@ -138,7 +138,7 @@ function isNodeExported(node: ts.Node): boolean {
   );
 }
 
-function evaluateTypeNode(node: ts.TypeNode): PropType | SnippetType | (PropType | SnippetType)[] {
+function evaluateTypeNode(node: ts.TypeNode): PropType | (PropType | SnippetType)[] {
   if (ts.isUnionTypeNode(node)) {
     return node.types.map(evaluateTypeNode) as PropType[];
   }

--- a/docgen/props/parseInterface.ts
+++ b/docgen/props/parseInterface.ts
@@ -158,7 +158,15 @@ function evaluateTypeNode(node: ts.TypeNode): PropType | SnippetType | (PropType
 
   const name = node.getText().trim();
 
-  const typesToIgnore = ["MaterialSymbol", "MouseEventHandler", "Snippet", "HTML", "Q.", "Exclude"];
+  const typesToIgnore = [
+    "MaterialSymbol",
+    "MouseEventHandler",
+    "Snippet",
+    "HTML",
+    "Q.",
+    "Exclude",
+    "Omit",
+  ];
 
   return {
     name,

--- a/docgen/props/worker.ts
+++ b/docgen/props/worker.ts
@@ -19,13 +19,22 @@ parentPort.on("message", async (workerData) => {
   const parsedInterface = parseInterface(propsFilePath);
   const types = await parseTypes(propsFilePath);
 
-  let contents = "";
+  let contents = 'import { ParsedProp, ParsedSnippet } from "$docgen/props/parseInterface"\n\n';
 
   Object.keys(parsedInterface).forEach((varName) => {
     const interfaceResults = parsedInterface[varName];
 
-    contents += `export const ${varName.replace(/Props$/, "DocsProps")} = ${JSON.stringify(
-      interfaceResults,
+    const props = interfaceResults.filter((prop) => !prop.isSnippet);
+    const snippets = interfaceResults.filter((prop) => prop.isSnippet);
+
+    contents += `export const ${varName.replace(/Props$/, "DocsProps")}: ParsedProp[] = ${JSON.stringify(
+      props,
+      null,
+      2
+    )};\n\n`;
+
+    contents += `export const ${varName.replace(/Props$/, "DocsSnippets")}: ParsedSnippet[] = ${JSON.stringify(
+      snippets,
       null,
       2
     )};\n\n`;

--- a/docgen/snippets/getInfo.ts
+++ b/docgen/snippets/getInfo.ts
@@ -24,13 +24,13 @@ export default async function getInfo(
   }
 
   const sections = await parseSvelteFile(pageFilePath);
-  const hashSections = await generateHash(stringifySectionsForHash(sections));
+  const hashSections = generateHash(stringifySectionsForHash(sections));
 
   if (!(await pathExists(docsSnippetsFilePath))) {
     return { needsToBeGenerated: true, hashSections, sections };
   }
 
-  const hashFromDocsProps = await extractHash(await readFile(docsSnippetsFilePath, "utf8"));
+  const hashFromDocsProps = extractHash(await readFile(docsSnippetsFilePath, "utf8"));
   const needsToBeGenerated = hashSections !== hashFromDocsProps;
 
   return { needsToBeGenerated, hashSections, sections };

--- a/docgen/snippets/getSnippetPagePaths.ts
+++ b/docgen/snippets/getSnippetPagePaths.ts
@@ -6,7 +6,7 @@ const dirname = path.dirname(fileURLToPath(import.meta.url));
 const rootDir = path.resolve(dirname, "../../src/routes/components");
 
 export default async function getSnippetPagePaths() {
-  const componentsToIgnore = ["layout"];
+  const componentsToIgnore = ["layout", "private"];
 
   const componentDirs = (await getComponentDirs(rootDir)).filter(
     (dir) => !componentsToIgnore.includes(dir)

--- a/src/lib/components/avatar/docs.ts
+++ b/src/lib/components/avatar/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QAvatarDocsProps } from "./docs.props";
+import { QAvatarDocsProps, QAvatarDocsSnippets } from "./docs.props";
 
 export const QAvatarDocs: QComponentDocs = {
   name: "QAvatar",
@@ -7,12 +7,7 @@ export const QAvatarDocs: QComponentDocs = {
     "Avatars can be used in many different ways as with icons or for user profile images/videos, for example. They can have many different shapes, the default one being a circle.",
   docs: {
     props: QAvatarDocsProps,
-    slots: [
-      {
-        name: "default",
-        description: "The default slot can be used to display initials inside the avatar.",
-      },
-    ],
+    snippets: QAvatarDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/breadcrumbs/docs.ts
+++ b/src/lib/components/breadcrumbs/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QBreadcrumbsDocsProps } from "./docs.props";
+import { QBreadcrumbsDocsProps, QBreadcrumbsDocsSnippets } from "./docs.props";
 
 export const QBreadcrumbsDocs: QComponentDocs = {
   name: "QBreadcrumbs",
@@ -7,13 +7,7 @@ export const QBreadcrumbsDocs: QComponentDocs = {
     "Breadcrumbs are mostly used as a navigation aid. They allow users to keep track of their location within the page.",
   docs: {
     props: QBreadcrumbsDocsProps,
-    slots: [
-      {
-        name: "default",
-        description:
-          "The default slot is used to inserts breadcrumb elements. Use QBreadcrumbsEl to insert elements.",
-      },
-    ],
+    snippets: QBreadcrumbsDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/button/docs.ts
+++ b/src/lib/components/button/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QBtnDocsProps } from "./docs.props";
+import { QBtnDocsProps, QBtnDocsSnippets } from "./docs.props";
 
 export const QBtnDocs: QComponentDocs = {
   name: "QBtn",
@@ -7,13 +7,7 @@ export const QBtnDocs: QComponentDocs = {
     "Buttons help users take action, such as sending an email, sharing a document, or liking a comment.",
   docs: {
     props: QBtnDocsProps,
-    slots: [
-      {
-        name: "default",
-        description:
-          "The default slot can be used to display the button's text. This slot doesn't overwrite the label prop but appends to it.",
-      },
-    ],
+    snippets: QBtnDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/card/docs.ts
+++ b/src/lib/components/card/docs.ts
@@ -1,5 +1,12 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QCardActionsDocsProps, QCardDocsProps, QCardSectionDocsProps } from "./docs.props";
+import {
+  QCardActionsDocsProps,
+  QCardActionsDocsSnippets,
+  QCardDocsProps,
+  QCardDocsSnippets,
+  QCardSectionDocsProps,
+  QCardSectionDocsSnippets,
+} from "./docs.props";
 
 export const QCardDocs: QComponentDocs = {
   name: "QCard",
@@ -7,12 +14,7 @@ export const QCardDocs: QComponentDocs = {
     "Cards provide a clean, flexible, and convenient means of displaying a wide variety of content.",
   docs: {
     props: QCardDocsProps,
-    slots: [
-      {
-        name: "default",
-        description: "Use this slot to add content to the card.",
-      },
-    ],
+    snippets: QCardDocsSnippets,
     methods: [],
     events: [],
   },
@@ -23,12 +25,7 @@ export const QCardSectionDocs: QComponentDocs = {
   description: "Sections are used to group similar content within a card.",
   docs: {
     props: QCardSectionDocsProps,
-    slots: [
-      {
-        name: "default",
-        description: "Use this slot to add content to the card section.",
-      },
-    ],
+    snippets: QCardSectionDocsSnippets,
     methods: [],
     events: [],
   },
@@ -39,12 +36,7 @@ export const QCardActionsDocs: QComponentDocs = {
   description: "Actions hold actionable items like buttons within a card.",
   docs: {
     props: QCardActionsDocsProps,
-    slots: [
-      {
-        name: "default",
-        description: "Use this slot to add action items to the card.",
-      },
-    ],
+    snippets: QCardActionsDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/checkbox/docs.ts
+++ b/src/lib/components/checkbox/docs.ts
@@ -1,12 +1,12 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QCheckboxDocsProps } from "./docs.props";
+import { QCheckboxDocsProps, QCheckboxDocsSnippets } from "./docs.props";
 
 export const QCheckboxDocs: QComponentDocs = {
   name: "QCheckbox",
   description: "Checkboxes allow the user to select one or more items from a set.",
   docs: {
     props: QCheckboxDocsProps,
-    slots: [],
+    snippets: QCheckboxDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/chip/docs.ts
+++ b/src/lib/components/chip/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QChipDocsProps } from "./docs.props";
+import { QChipDocsProps, QChipDocsSnippets } from "./docs.props";
 
 export const QChipDocs: QComponentDocs = {
   name: "QChip",
@@ -7,23 +7,7 @@ export const QChipDocs: QComponentDocs = {
     "Chips help people enter information, make selections, filter content, or trigger actions. They represent options in a specific context, unlike buttons, which are persistent.",
   docs: {
     props: QChipDocsProps,
-    slots: [
-      {
-        name: "default",
-        description:
-          'The default slot for the chip\'s content. Is overwritten by the "content" prop',
-      },
-      {
-        name: "leading",
-        description:
-          "Slot for content to display at the start of the chip. Use with an icon or a media.",
-      },
-      {
-        name: "trailing",
-        description:
-          "Slot for content to display at the end of the chip. Use with an icon or a media.",
-      },
-    ],
+    snippets: QChipDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/codeBlock/QCodeBlock.svelte
+++ b/src/lib/components/codeBlock/QCodeBlock.svelte
@@ -1,8 +1,6 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { copy } from "$lib/utils";
   import { QBtn } from "$lib";
-  import type { CodeToHastOptions, BundledLanguage, BundledTheme } from "shiki";
   import type { QCodeBlockProps } from "./props";
 
   let {
@@ -16,24 +14,11 @@
   let btnContent = $state("Copy");
   let btnColor = $state("primary");
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  let codeToHtml = async (str: string, opts: CodeToHastOptions<BundledLanguage, BundledTheme>) =>
-    "";
-
-  async function loadShiki() {
-    try {
-      // prevent vite "optimization", which would lead to errors here
-      const shikiPackage = "shiki";
-      const { codeToHtml: codeToHtmlShiki } = await import(/* @vite-ignore */ shikiPackage);
-      codeToHtml = codeToHtmlShiki;
-    } catch (e) {
-      console.error("error loading shiki, please make sure it is installed", e);
-    }
-  }
-
   const html = $derived.by(
     async () =>
-      await codeToHtml(code, {
+      await (
+        await import(/* @vite-ignore */ "shiki")
+      ).codeToHtml(code, {
         lang: language,
         theme,
       })
@@ -67,8 +52,6 @@
       setBtn("base");
     }, 3000);
   }
-
-  onMount(() => loadShiki());
 </script>
 
 <div class="q-code-block" data-quaff>
@@ -102,10 +85,12 @@
 
 <style>
   .q-code-block {
-    border-radius: 0.5em;
+    border-radius: inherit;
 
     :global(pre) {
       white-space: break-spaces;
+      text-align: left;
+      padding: 1rem;
     }
   }
 </style>

--- a/src/lib/components/dialog/docs.ts
+++ b/src/lib/components/dialog/docs.ts
@@ -1,12 +1,12 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QDialogDocsProps } from "./docs.props";
+import { QDialogDocsProps, QDialogDocsSnippets } from "./docs.props";
 
 export const QDialogDocs: QComponentDocs = {
   name: "QDialog",
   description: "Dialogs provide important prompts in a user flow.",
   docs: {
     props: QDialogDocsProps,
-    slots: [],
+    snippets: QDialogDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/drawer/docs.ts
+++ b/src/lib/components/drawer/docs.ts
@@ -1,12 +1,12 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QDrawerDocsProps } from "./docs.props";
+import { QDrawerDocsProps, QDrawerDocsSnippets } from "./docs.props";
 
 export const QDrawerDocs: QComponentDocs = {
   name: "QDrawer",
   description: "Navigation drawers provide ergonomic access to destinations in an app",
   docs: {
     props: QDrawerDocsProps,
-    slots: [],
+    snippets: QDrawerDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/footer/docs.ts
+++ b/src/lib/components/footer/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QFooterDocsProps } from "./docs.props";
+import { QFooterDocsProps, QFooterDocsSnippets } from "./docs.props";
 
 export const QFooterDocs: QComponentDocs = {
   name: "QFooter",
@@ -7,7 +7,7 @@ export const QFooterDocs: QComponentDocs = {
     "Footers can be used to display navigation and key actions at the bottom of the screen.",
   docs: {
     props: QFooterDocsProps,
-    slots: [],
+    snippets: QFooterDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/icon/docs.ts
+++ b/src/lib/components/icon/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QIconDocsProps } from "./docs.props";
+import { QIconDocsProps, QIconDocsSnippets } from "./docs.props";
 
 export const QIconDocs: QComponentDocs = {
   name: "QIcon",
@@ -7,7 +7,7 @@ export const QIconDocs: QComponentDocs = {
     "This component allows you to insert icons within elements of the page. Supported cions are Material Symbols icons.",
   docs: {
     props: QIconDocsProps,
-    slots: [],
+    snippets: QIconDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/input/docs.ts
+++ b/src/lib/components/input/docs.ts
@@ -1,73 +1,13 @@
 import type { QComponentDocs } from "$lib/utils";
+import { QInputDocsProps, QInputDocsSnippets } from "./docs.props";
 
 export const QInputDocs: QComponentDocs = {
   name: "QInput",
   description:
     "QInput is a form component that allows users to input text. It supports different visual styles such as filled, outlined, and rounded, and it can also display hint text and custom error messages.",
   docs: {
-    props: [
-      {
-        name: "disable",
-        type: "boolean",
-        default: false,
-        description: "Whether the input component is disabled.",
-      },
-      {
-        name: "error",
-        type: "boolean",
-        default: false,
-        description: "Whether the input component is in an error state.",
-      },
-      {
-        name: "errorMessage",
-        type: "string",
-        optional: true,
-        description: "Custom error message to show when the input component is in an error state.",
-      },
-      {
-        name: "filled",
-        type: "boolean",
-        default: false,
-        description: "Whether the input component has a filled style.",
-      },
-      {
-        name: "hint",
-        type: "string",
-        optional: true,
-        description: "Hint text to show under the input component.",
-      },
-      {
-        name: "label",
-        type: "string",
-        optional: true,
-        description: "Label for the input component.",
-      },
-      {
-        name: "outlined",
-        type: "boolean",
-        default: false,
-        description: "Whether the input component has an outlined style.",
-      },
-      {
-        name: "rounded",
-        type: "boolean",
-        default: false,
-        description: "Whether the input component has rounded corners.",
-      },
-      {
-        name: "dense",
-        type: "boolean",
-        optional: true,
-        description: "Whether the input component has a smaller (dense) size.",
-      },
-      {
-        name: "value",
-        type: "string",
-        default: "",
-        description: "Current value of the input component.",
-      },
-    ],
-    slots: [],
+    props: QInputDocsProps,
+    snippets: QInputDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/layout/docs.ts
+++ b/src/lib/components/layout/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QLayoutDocsProps } from "./docs.props";
+import { QLayoutDocsProps, QLayoutDocsSnippets } from "./docs.props";
 
 export const QLayoutDocs: QComponentDocs = {
   name: "QLayout",
@@ -7,7 +7,7 @@ export const QLayoutDocs: QComponentDocs = {
     "The QLayout component is designed to be the skeleton of the entire page, with navigational elements such as header, railbars, drawers and footer. This component is not mandatory but it really helps structure the page.",
   docs: {
     props: QLayoutDocsProps,
-    slots: [],
+    snippets: QLayoutDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/list/docs.ts
+++ b/src/lib/components/list/docs.ts
@@ -1,5 +1,12 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QListDocsProps, QListDocsSnippets } from "./docs.props";
+import {
+  QItemDocsProps,
+  QItemDocsSnippets,
+  QItemSectionDocsProps,
+  QItemSectionDocsSnippets,
+  QListDocsProps,
+  QListDocsSnippets,
+} from "./docs.props";
 
 export const QListDocs: QComponentDocs = {
   name: "QList",
@@ -8,6 +15,30 @@ export const QListDocs: QComponentDocs = {
   docs: {
     props: QListDocsProps,
     snippets: QListDocsSnippets,
+    methods: [],
+    events: [],
+  },
+};
+
+export const QItemDocs: QComponentDocs = {
+  name: "QItem",
+  description:
+    "The QItem component is generally used inside lists to display related pieces of information.",
+  docs: {
+    props: QItemDocsProps,
+    snippets: QItemDocsSnippets,
+    methods: [],
+    events: [],
+  },
+};
+
+export const QItemSectionDocs: QComponentDocs = {
+  name: "QItemSection",
+  description:
+    "The QItemSection component is used inside QItem to separate different types of information.",
+  docs: {
+    props: QItemSectionDocsProps,
+    snippets: QItemSectionDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/list/docs.ts
+++ b/src/lib/components/list/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QListDocsProps } from "./docs.props";
+import { QListDocsProps, QListDocsSnippets } from "./docs.props";
 
 export const QListDocs: QComponentDocs = {
   name: "QList",
@@ -7,7 +7,7 @@ export const QListDocs: QComponentDocs = {
     "The QList component is used to display a list of items with options for adding text, icons and actions.",
   docs: {
     props: QListDocsProps,
-    slots: [],
+    snippets: QListDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/list/props.ts
+++ b/src/lib/components/list/props.ts
@@ -1,6 +1,6 @@
 import type { RouterProps } from "$lib/utils/router";
 import type { Snippet } from "svelte";
-import type { QSeparatorProps } from "../separator/props";
+import type { QSeparatorHorizontalProps } from "../separator/props";
 import type { HTMLAnchorAttributes, HTMLAttributes } from "svelte/elements";
 
 export interface QListProps extends HTMLAttributes<HTMLElement> {
@@ -8,7 +8,7 @@ export interface QListProps extends HTMLAttributes<HTMLElement> {
   roundedBorders?: boolean;
   dense?: boolean;
   separator?: boolean;
-  separatorOptions?: Omit<QSeparatorProps, "vertical">;
+  separatorOptions?: Omit<QSeparatorHorizontalProps, "vertical">;
   padding?: boolean;
   tag?: string;
 }

--- a/src/lib/components/list/props.ts
+++ b/src/lib/components/list/props.ts
@@ -8,14 +8,7 @@ export interface QListProps extends HTMLAttributes<HTMLElement> {
   roundedBorders?: boolean;
   dense?: boolean;
   separator?: boolean;
-  separatorOptions?: {
-    spacing?: QSeparatorProps["spacing"];
-    inset?: QSeparatorProps["inset"];
-    color?: QSeparatorProps["color"];
-    size?: QSeparatorProps["size"];
-    text?: QSeparatorProps["text"];
-    textAlign?: QSeparatorProps["textAlign"];
-  };
+  separatorOptions?: Exclude<QSeparatorProps, "vertical">;
   padding?: boolean;
   tag?: string;
 }

--- a/src/lib/components/list/props.ts
+++ b/src/lib/components/list/props.ts
@@ -8,7 +8,7 @@ export interface QListProps extends HTMLAttributes<HTMLElement> {
   roundedBorders?: boolean;
   dense?: boolean;
   separator?: boolean;
-  separatorOptions?: Exclude<QSeparatorProps, "vertical">;
+  separatorOptions?: Omit<QSeparatorProps, "vertical">;
   padding?: boolean;
   tag?: string;
 }

--- a/src/lib/components/private/QApi.svelte
+++ b/src/lib/components/private/QApi.svelte
@@ -145,7 +145,7 @@
 
   $effect(() => {
     // Doesn't rerun if we don't use JSON.stringify
-    void JSON.stringify(api);
+    JSON.stringify(api);
 
     attachTooltips();
   });

--- a/src/lib/components/progress/docs.ts
+++ b/src/lib/components/progress/docs.ts
@@ -1,13 +1,30 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QLinearProgressDocsProps } from "./docs.props";
+import {
+  QLinearProgressDocsProps,
+  QLinearProgressDocsSnippets,
+  QCircularProgressDocsProps,
+  QCircularProgressDocsSnippets,
+} from "./docs.props";
 
-export const QProgressDocs: QComponentDocs = {
+export const QLinearProgressDocs: QComponentDocs = {
   name: "QProgress",
   description:
-    "The QProgress component is used to display a progress bar, indicating the completion status of a task or process.",
+    "The QLinearProgress component is used to display a progress bar, indicating the completion status of a task or process.",
   docs: {
     props: QLinearProgressDocsProps,
-    slots: [],
+    snippets: QLinearProgressDocsSnippets,
+    methods: [],
+    events: [],
+  },
+};
+
+export const QCircularProgressDocs: QComponentDocs = {
+  name: "QProgress",
+  description:
+    "The QCircularProgress component is used to display a cicular progress bar, indicating the completion status of a task or process.",
+  docs: {
+    props: QCircularProgressDocsProps,
+    snippets: QCircularProgressDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/radio/docs.ts
+++ b/src/lib/components/radio/docs.ts
@@ -1,34 +1,12 @@
 import type { QComponentDocs } from "$lib/utils";
+import { QRadioDocsProps, QRadioDocsSnippets } from "./docs.props";
 
 export const QRadioDocs: QComponentDocs = {
   name: "QRadio",
   description: "Radio buttons allow the user to select one option from a set.",
   docs: {
-    props: [
-      {
-        name: "value",
-        type: "string",
-        default: "",
-        description: "The value of the radio button.",
-      },
-      {
-        name: "label",
-        type: "string",
-        description: "The label of the radio button.",
-      },
-      {
-        name: "selected",
-        type: "any",
-        description: "The currently selected value in the radio group.",
-      },
-      {
-        name: "disable",
-        type: "boolean",
-        default: false,
-        description: "Disable the radio button.",
-      },
-    ],
-    slots: [],
+    props: QRadioDocsProps,
+    snippets: QRadioDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/railbar/docs.ts
+++ b/src/lib/components/railbar/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QRailbarDocsProps } from "./docs.props";
+import { QRailbarDocsProps, QRailbarDocsSnippets } from "./docs.props";
 
 export const QRailbarDocs: QComponentDocs = {
   name: "QRailbar",
@@ -7,7 +7,7 @@ export const QRailbarDocs: QComponentDocs = {
     "Railbars are used to provide navigation between different sections or views within an application.",
   docs: {
     props: QRailbarDocsProps,
-    slots: [],
+    snippets: QRailbarDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/select/docs.ts
+++ b/src/lib/components/select/docs.ts
@@ -1,92 +1,13 @@
 import type { QComponentDocs } from "$lib/utils";
+import { QSelectDocsProps, QSelectDocsSnippets } from "./docs.props";
 
 export const QSelectDocs: QComponentDocs = {
   name: "QSelect",
   description:
     "QSelect is a form component that allows users to choose from multiple options in a dropdown list. It supports single and multiple selection, as well as different visual styles such as filled, outlined, and rounded.",
   docs: {
-    props: [
-      {
-        name: "value",
-        type: "string | string[]",
-        default: "",
-        description: "Current value(s) of the select component.",
-      },
-      {
-        name: "multiple",
-        type: "boolean",
-        default: false,
-        description: "Whether the select component supports multiple selection.",
-      },
-      {
-        name: "options",
-        type: "QSelectOption[]",
-        description: "Options available for selection.",
-        clickableType: true,
-      },
-      {
-        name: "disable",
-        type: "boolean",
-        default: false,
-        description: "Whether the select component is disabled.",
-      },
-      {
-        name: "displayValue",
-        type: "string",
-        default: undefined,
-        optional: true,
-        description: "Custom display value to show instead of the plain option(s).",
-      },
-      {
-        name: "error",
-        type: "boolean",
-        default: false,
-        description: "Whether the select component is in an error state.",
-      },
-      {
-        name: "errorMessage",
-        type: "string",
-        optional: true,
-        description: "Custom error message to show when the select component is in an error state.",
-      },
-      {
-        name: "filled",
-        type: "boolean",
-        default: false,
-        description: "Whether the select component has a filled style.",
-      },
-      {
-        name: "hint",
-        type: "string",
-        optional: true,
-        description: "Hint text to show under the select component.",
-      },
-      {
-        name: "label",
-        type: "string",
-        optional: true,
-        description: "Label for the select component.",
-      },
-      {
-        name: "outlined",
-        type: "boolean",
-        default: false,
-        description: "Whether the select component has an outlined style.",
-      },
-      {
-        name: "rounded",
-        type: "boolean",
-        default: false,
-        description: "Whether the select component has rounded corners.",
-      },
-      {
-        name: "dense",
-        type: "boolean",
-        optional: true,
-        description: "Whether the select component has a smaller (dense) size.",
-      },
-    ],
-    slots: [],
+    props: QSelectDocsProps,
+    snippets: QSelectDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/separator/docs.ts
+++ b/src/lib/components/separator/docs.ts
@@ -1,13 +1,30 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QSeparatorPropsVertical } from "./docs.props";
+import {
+  QSeparatorVerticalDocsSnippets,
+  QSeparatorVerticalDocsProps,
+  QSeparatorHorizontalDocsProps,
+  QSeparatorHorizontalDocsSnippets,
+} from "./docs.props";
 
-export const QSeparatorDocs: QComponentDocs = {
+export const QSeparatorVerticalDocs: QComponentDocs = {
   name: "QSeparator",
   description:
     "Separators can be used to create a dividing line or space between elements within a layout, offering visual separation and organization.",
   docs: {
-    props: QSeparatorPropsVertical,
-    slots: [],
+    props: QSeparatorVerticalDocsProps,
+    snippets: QSeparatorVerticalDocsSnippets,
+    methods: [],
+    events: [],
+  },
+};
+
+export const QSeparatorHorizontalDocs: QComponentDocs = {
+  name: "QSeparator",
+  description:
+    "Separators can be used to create a dividing line or space between elements within a layout, offering visual separation and organization.",
+  docs: {
+    props: QSeparatorHorizontalDocsProps,
+    snippets: QSeparatorHorizontalDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/separator/docs.ts
+++ b/src/lib/components/separator/docs.ts
@@ -7,7 +7,7 @@ import {
 } from "./docs.props";
 
 export const QSeparatorVerticalDocs: QComponentDocs = {
-  name: "QSeparator",
+  name: "QSeparator (Vertical)",
   description:
     "Separators can be used to create a dividing line or space between elements within a layout, offering visual separation and organization.",
   docs: {

--- a/src/lib/components/separator/props.ts
+++ b/src/lib/components/separator/props.ts
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from "svelte/elements";
 
-interface QSeparatorPropsVertical extends HTMLAttributes<HTMLDivElement> {
+interface QSeparatorVerticalProps extends HTMLAttributes<HTMLDivElement> {
   spacing?: Q.Size;
   inset?: boolean;
   vertical?: true;
@@ -10,7 +10,7 @@ interface QSeparatorPropsVertical extends HTMLAttributes<HTMLDivElement> {
   textAlign?: "top" | "middle" | "bottom";
 }
 
-interface QSeparatorPropsHorizontal extends HTMLAttributes<HTMLDivElement> {
+interface QSeparatorHorizontalProps extends HTMLAttributes<HTMLDivElement> {
   spacing?: Q.Size;
   inset?: boolean;
   vertical?: false;
@@ -20,4 +20,4 @@ interface QSeparatorPropsHorizontal extends HTMLAttributes<HTMLDivElement> {
   textAlign?: "left" | "center" | "right";
 }
 
-export type QSeparatorProps = QSeparatorPropsHorizontal | QSeparatorPropsVertical;
+export type QSeparatorProps = QSeparatorHorizontalProps | QSeparatorVerticalProps;

--- a/src/lib/components/separator/props.ts
+++ b/src/lib/components/separator/props.ts
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from "svelte/elements";
 
-interface QSeparatorVerticalProps extends HTMLAttributes<HTMLDivElement> {
+interface QSeparatorVerticalProps {
   spacing?: Q.Size;
   inset?: boolean;
   vertical?: true;
@@ -10,7 +10,7 @@ interface QSeparatorVerticalProps extends HTMLAttributes<HTMLDivElement> {
   textAlign?: "top" | "middle" | "bottom";
 }
 
-interface QSeparatorHorizontalProps extends HTMLAttributes<HTMLDivElement> {
+interface QSeparatorHorizontalProps {
   spacing?: Q.Size;
   inset?: boolean;
   vertical?: false;
@@ -20,4 +20,5 @@ interface QSeparatorHorizontalProps extends HTMLAttributes<HTMLDivElement> {
   textAlign?: "left" | "center" | "right";
 }
 
-export type QSeparatorProps = QSeparatorHorizontalProps | QSeparatorVerticalProps;
+export type QSeparatorProps = (QSeparatorHorizontalProps | QSeparatorVerticalProps) &
+  HTMLAttributes<HTMLDivElement>;

--- a/src/lib/components/separator/props.ts
+++ b/src/lib/components/separator/props.ts
@@ -1,6 +1,6 @@
 import type { HTMLAttributes } from "svelte/elements";
 
-interface QSeparatorVerticalProps {
+export interface QSeparatorVerticalProps {
   spacing?: Q.Size;
   inset?: boolean;
   vertical?: true;
@@ -10,7 +10,7 @@ interface QSeparatorVerticalProps {
   textAlign?: "top" | "middle" | "bottom";
 }
 
-interface QSeparatorHorizontalProps {
+export interface QSeparatorHorizontalProps {
   spacing?: Q.Size;
   inset?: boolean;
   vertical?: false;

--- a/src/lib/components/switch/docs.ts
+++ b/src/lib/components/switch/docs.ts
@@ -1,43 +1,13 @@
 import type { QComponentDocs } from "$lib/utils";
+import { QSwitchDocsProps, QSwitchDocsSnippets } from "./docs.props";
 
 export const QSwitchDocs: QComponentDocs = {
   name: "QSwitch",
   description:
     "QSwitch is a switch-like checkbox which offers binary choices. It supports labels, icons and different positioning of the labels.",
   docs: {
-    props: [
-      {
-        name: "value",
-        type: "boolean",
-        default: false,
-        description: "The current value of the toggle, true or false.",
-      },
-      {
-        name: "label",
-        type: "string",
-        optional: true,
-        description: "Label to be shown alongside the toggle.",
-      },
-      {
-        name: "leftLabel",
-        type: "boolean",
-        default: false,
-        description: "Whether the label should be displayed to the left of the toggle.",
-      },
-      {
-        name: "icon",
-        type: "string",
-        optional: true,
-        description: "Name of the icon to display on the toggle.",
-      },
-      {
-        name: "disable",
-        type: "boolean",
-        default: false,
-        description: "Whether the toggle should be disabled.",
-      },
-    ],
-    slots: [],
+    props: QSwitchDocsProps,
+    snippets: QSwitchDocsSnippets,
     methods: [],
     events: [
       {

--- a/src/lib/components/table/docs.ts
+++ b/src/lib/components/table/docs.ts
@@ -1,12 +1,12 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QTableDocsProps } from "./docs.props";
+import { QTableDocsProps, QTableDocsSnippets } from "./docs.props";
 
 export const QTableDocs: QComponentDocs = {
   name: "QTable",
   description: "Tables allow for a clear presentation of data sets.",
   docs: {
     props: QTableDocsProps,
-    slots: [],
+    snippets: QTableDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/tabs/QTabs.scss
+++ b/src/lib/components/tabs/QTabs.scss
@@ -10,8 +10,13 @@
   scroll-behavior: smooth;
   border-radius: 0;
   border-bottom: solid 0.0625rem var(--outline);
+
   &::-webkit-scrollbar {
     display: none;
+  }
+
+  &.q-tabs--no-separator {
+    border: unset;
   }
 
   &.q-tabs--secondary .q-tab .q-tab__indicator {
@@ -25,6 +30,10 @@
     align-items: stretch;
     border-bottom: unset;
     border-right: solid 0.0625rem var(--outline);
+
+    &.q-tabs--no-separator {
+      border: unset;
+    }
 
     & > .q-tab {
       @include mixins.padding("x-md");

--- a/src/lib/components/tabs/QTabs.svelte
+++ b/src/lib/components/tabs/QTabs.svelte
@@ -1,4 +1,4 @@
-<script context="module" lang="ts">
+<script module lang="ts">
   export type QTabEl = HTMLAnchorElement | HTMLButtonElement;
   export type QTabsElementsContext = {
     previous: QTabEl | null;
@@ -16,6 +16,7 @@
     value = $bindable(),
     variant = "primary",
     round = false,
+    noSeparator = false,
     children,
     ...props
   }: QTabsProps = $props();
@@ -137,6 +138,7 @@
     bemClasses: {
       rounded: round,
       [variant]: true,
+      "no-separator": noSeparator,
     },
     classes: [props.class],
   });

--- a/src/lib/components/tabs/docs.ts
+++ b/src/lib/components/tabs/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QTabsDocsProps } from "./docs.props";
+import { QTabDocsProps, QTabDocsSnippets, QTabsDocsProps, QTabsDocsSnippets } from "./docs.props";
 
 export const QTabsDocs: QComponentDocs = {
   name: "QTabs",
@@ -7,7 +7,19 @@ export const QTabsDocs: QComponentDocs = {
     "Tabs allow creating navigational tabs, enabling users to switch between different views or functional aspects.",
   docs: {
     props: QTabsDocsProps,
-    slots: [],
+    snippets: QTabsDocsSnippets,
+    methods: [],
+    events: [],
+  },
+};
+
+export const QTabDocs: QComponentDocs = {
+  name: "QTabs",
+  description:
+    "Tabs allow creating navigational tabs, enabling users to switch between different views or functional aspects.",
+  docs: {
+    props: QTabDocsProps,
+    snippets: QTabDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/tabs/props.ts
+++ b/src/lib/components/tabs/props.ts
@@ -8,6 +8,7 @@ export interface QTabsProps extends HTMLAttributes<HTMLElement> {
   value?: string;
   variant?: QTabsVariants;
   round?: boolean;
+  noSeparator?: boolean;
 }
 
 export interface QTabProps extends HTMLAttributes<HTMLElement> {

--- a/src/lib/components/toolbar/docs.ts
+++ b/src/lib/components/toolbar/docs.ts
@@ -1,5 +1,5 @@
 import type { QComponentDocs } from "$lib/utils";
-import { QToolbarDocsProps } from "./docs.props";
+import { QToolbarDocsProps, QToolbarDocsSnippets } from "./docs.props";
 
 export const QToolbarDocs: QComponentDocs = {
   name: "QToolbar",
@@ -7,7 +7,7 @@ export const QToolbarDocs: QComponentDocs = {
     "The Toolbar component is used to hold common actions and controls, often located at the top of an application or view.",
   docs: {
     props: QToolbarDocsProps,
-    slots: [],
+    snippets: QToolbarDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/tooltip/QTooltip.scss
+++ b/src/lib/components/tooltip/QTooltip.scss
@@ -21,4 +21,9 @@
   font-weight: 500;
   transition: opacity variables.$speed2;
   z-index: 9999;
+
+  &__helper {
+    // Remove the helper element from the flow so it doesn't affect pre elements
+    position: absolute;
+  }
 }

--- a/src/lib/components/tooltip/QTooltip.svelte
+++ b/src/lib/components/tooltip/QTooltip.svelte
@@ -68,8 +68,8 @@
 
       windowWheelListener?.remove();
 
-      if (tooltipHelperEl && realTarget && realTarget.contains(tooltipHelperEl)) {
-        realTarget.removeChild(tooltipHelperEl);
+      if (mountedTooltip) {
+        unmount(mountedTooltip);
       }
 
       if (timerShow) {

--- a/src/lib/components/tooltip/QTooltip.svelte
+++ b/src/lib/components/tooltip/QTooltip.svelte
@@ -69,7 +69,7 @@
       windowWheelListener?.remove();
 
       if (tooltipHelperEl && realTarget) {
-        document.body.removeChild(tooltipHelperEl);
+        realTarget.removeChild(tooltipHelperEl);
       }
 
       if (timerShow) {

--- a/src/lib/components/tooltip/QTooltip.svelte
+++ b/src/lib/components/tooltip/QTooltip.svelte
@@ -68,7 +68,7 @@
 
       windowWheelListener?.remove();
 
-      if (tooltipHelperEl && realTarget) {
+      if (tooltipHelperEl && realTarget && realTarget.contains(tooltipHelperEl)) {
         realTarget.removeChild(tooltipHelperEl);
       }
 

--- a/src/lib/components/tooltip/docs.ts
+++ b/src/lib/components/tooltip/docs.ts
@@ -1,3 +1,4 @@
+import { QToolbarDocsSnippets } from "$components/header/docs.props";
 import type { QComponentDocs } from "$lib/utils";
 import { QTooltipDocsProps } from "./docs.props";
 
@@ -7,7 +8,7 @@ export const QTooltipDocs: QComponentDocs = {
     "The Tooltip component displays informative text on hover or focus, providing additional context.",
   docs: {
     props: QTooltipDocsProps,
-    slots: [],
+    snippets: QToolbarDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/tooltip/props.ts
+++ b/src/lib/components/tooltip/props.ts
@@ -1,5 +1,17 @@
 import type { HTMLAttributes } from "svelte/elements";
 
+export type QTooltipPosition =
+  | "top-left"
+  | "top"
+  | "top-right"
+  | "right"
+  | "bottom-right"
+  | "bottom"
+  | "bottom-left"
+  | "left";
+
+export type QTooltipOffset = { x?: number; y?: number };
+
 export interface QTooltipProps<T extends Element | string> extends HTMLAttributes<HTMLDivElement> {
   /**
    * The target element the tooltip should be attached to. Can be an HTML element or a CSS selector. If not specified, the tooltip will be attached to the nearest Quaff component in the parent tree.
@@ -17,21 +29,13 @@ export interface QTooltipProps<T extends Element | string> extends HTMLAttribute
    * Defines the position of the tooltip.
    * @default "bottom"
    */
-  position?:
-    | "top-left"
-    | "top"
-    | "top-right"
-    | "right"
-    | "bottom-right"
-    | "bottom"
-    | "bottom-left"
-    | "left";
+  position?: QTooltipPosition;
 
   /**
    * Offset of the tooltip in pixels. Positive values move the tooltip down/right, negative values move the tooltip up/left.
    * @default { x: 0, y: 0 }
    */
-  offset?: { x?: number; y?: number };
+  offset?: QTooltipOffset;
 
   /**
    * Delay in milliseconds before the tooltip appears.

--- a/src/lib/utils/string.ts
+++ b/src/lib/utils/string.ts
@@ -90,3 +90,12 @@ export function convertCase(str: string, fromCase: keyof typeof cases, toCase: k
 export function extractImgSrc(prop?: string) {
   return prop?.startsWith("img:") ? prop.slice(4) : undefined;
 }
+
+export function escape(str: string) {
+  return str
+    .replace("&", "&amp;")
+    .replace('"', "&quot;")
+    .replace("'", "&#39;")
+    .replace("<", "&lt;")
+    .replace(">", "&gt;");
+}

--- a/src/lib/utils/types.ts
+++ b/src/lib/utils/types.ts
@@ -1,3 +1,5 @@
+import { ParsedProp, ParsedSnippet } from "../../../docgen/props/parseInterface";
+
 export interface NativeProps {
   userClasses?: string | null;
   userStyles?: string | null;
@@ -18,25 +20,11 @@ export interface QComponentDocs {
   name: string;
   description: string;
   docs: {
-    props: QComponentProp[];
-    slots: QComponentSlot[];
+    props: ParsedProp[];
+    snippets: ParsedSnippet[];
     methods: QComponentMethod[];
     events: QComponentEvent[];
   };
-}
-
-export interface QComponentProp {
-  name: string;
-  type: string;
-  default?: unknown;
-  description: string;
-  clickableType?: boolean;
-  optional?: boolean;
-}
-
-export interface QComponentSlot {
-  name: string;
-  description: string;
 }
 
 export interface QComponentType {

--- a/src/routes/components/list/+page.svelte
+++ b/src/routes/components/list/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { QListDocs } from "$components/list/docs";
+  import { QListDocs, QItemDocs, QItemSectionDocs } from "$components/list/docs";
   import QDocs from "$lib/components/private/QDocs.svelte";
 </script>
 
-<QDocs componentDocs={QListDocs}>
+<QDocs componentDocs={[QListDocs, QItemDocs, QItemSectionDocs]}>
   {#snippet usage()}
     <div></div>
   {/snippet}

--- a/src/routes/components/progress/+page.svelte
+++ b/src/routes/components/progress/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { QProgressDocs } from "$components/progress/docs";
+  import { QLinearProgressDocs, QCircularProgressDocs } from "$components/progress/docs";
   import QDocs from "$lib/components/private/QDocs.svelte";
   import QDocsSection from "$lib/components/private/QDocsSection.svelte";
   import QLinearProgress from "$lib/components/progress/QLinearProgress.svelte";
   import QCircularProgress from "$lib/components/progress/QCircularProgress.svelte";
 </script>
 
-<QDocs componentDocs={QProgressDocs}>
+<QDocs componentDocs={[QLinearProgressDocs, QCircularProgressDocs]}>
   {#snippet usage()}
     <div>
       <QDocsSection title="Linear Progress">

--- a/src/routes/components/separator/+page.svelte
+++ b/src/routes/components/separator/+page.svelte
@@ -3,7 +3,7 @@
   import QDocs from "$lib/components/private/QDocs.svelte";
 </script>
 
-<QDocs componentDocs={[QSeparatorVerticalDocs, QSeparatorHorizontalDocs]}>
+<QDocs componentDocs={[QSeparatorHorizontalDocs, QSeparatorVerticalDocs]}>
   {#snippet usage()}
     <div></div>
   {/snippet}

--- a/src/routes/components/separator/+page.svelte
+++ b/src/routes/components/separator/+page.svelte
@@ -1,9 +1,9 @@
 <script lang="ts">
-  import { QSeparatorDocs } from "$components/separator/docs";
+  import { QSeparatorVerticalDocs, QSeparatorHorizontalDocs } from "$components/separator/docs";
   import QDocs from "$lib/components/private/QDocs.svelte";
 </script>
 
-<QDocs componentDocs={QSeparatorDocs}>
+<QDocs componentDocs={[QSeparatorVerticalDocs, QSeparatorHorizontalDocs]}>
   {#snippet usage()}
     <div></div>
   {/snippet}

--- a/src/routes/components/tabs/+page.svelte
+++ b/src/routes/components/tabs/+page.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
   import QTab from "$components/tabs/QTab.svelte";
   import QTabs from "$components/tabs/QTabs.svelte";
-  import { QTabsDocs } from "$components/tabs/docs";
+  import { QTabsDocs, QTabDocs } from "$components/tabs/docs";
   import QDocs from "$lib/components/private/QDocs.svelte";
   import QDocsSection from "$lib/components/private/QDocsSection.svelte";
 
   let activeTab = $state("hello");
 </script>
 
-<QDocs componentDocs={QTabsDocs}>
+<QDocs componentDocs={[QTabsDocs, QTabDocs]}>
   {#snippet usage()}
     <div>
       <QDocsSection title="Primary Tabs">

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -18,6 +18,7 @@ const config = {
     // See https://kit.svelte.dev/docs/adapters for more information about adapters.
     adapter: adapter(),
     alias: {
+      $docgen: "./docgen",
       $components: "./src/lib/components",
       $composables: "./src/lib/composables",
       $utils: "./src/lib/utils",

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig({
       $css: path.resolve(__dirname, "./src/lib/css"),
       $stores: path.resolve(__dirname, "./src/lib/stores"),
       $helpers: path.resolve(__dirname, "./src/lib/helpers"),
+      $docgen: path.resolve(__dirname, "./docgen"),
     },
   },
 });


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Replaced slots by snippets in the API docs
- Made snippets docs generation automatic (as opposed to slots)
- Improved the type checker inside API
- Replaced drawer displaying types definition on click by a tooltip (on mouseenter)
- Fixed some components that didn't work
- Made all component docs work with the new docs gen api
- Import "shiki" when `code` changes inside `QCodeBlock` instead of onMount

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

Closes #100 
