### PR TITLE
fix: add transition after layout elements are loaded to avoid unwanted movement

### DIFF
--- a/src/lib/components/drawer/QDrawer.scss
+++ b/src/lib/components/drawer/QDrawer.scss
@@ -17,12 +17,6 @@
 
   overflow: auto;
 
-  transition:
-    border-radius variables.$speed3,
-    transform variables.$speed3,
-    top variables.$speed3,
-    bottom variables.$speed3;
-
   &.q-drawer--overlay {
     z-index: 6;
   }

--- a/src/lib/components/drawer/QDrawer.svelte
+++ b/src/lib/components/drawer/QDrawer.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getContext, onDestroy, untrack } from "svelte";
+  import { getContext, onDestroy, onMount, untrack } from "svelte";
   import { navigating } from "$app/state";
   import { useSize } from "$lib/composables";
   import { QContext } from "$lib/classes/QContext.svelte";
@@ -54,6 +54,14 @@
     e?.stopPropagation();
   };
 
+  onMount(() => {
+    if (drawerContext) {
+      setTimeout(() => {
+        drawerEl.style.transition = "top 0.3s, bottom 0.3s, transform 0.3s";
+      }, 100);
+    }
+  });
+
   $effect(() => {
     if (navigating.type && hideOnRouteChange) {
       hide();
@@ -74,6 +82,7 @@
     drawerContext?.updateEntries({
       width: 0,
       takesSpace: false,
+      ready: false,
     });
   });
 
@@ -85,6 +94,7 @@
       drawerContext?.updateEntries({
         takesSpace: !!value && !overlay,
         width,
+        ready: true,
       })
     );
   });

--- a/src/lib/components/footer/QFooter.scss
+++ b/src/lib/components/footer/QFooter.scss
@@ -19,8 +19,6 @@
 
   background-color: var(--surface);
 
-  transition: all variables.$speed3;
-
   &.q-footer--bordered {
     @include mixins.border(var(--outline), "top");
   }

--- a/src/lib/components/footer/QFooter.svelte
+++ b/src/lib/components/footer/QFooter.svelte
@@ -9,6 +9,8 @@
 
   const footerIdentifier = Date.now();
 
+  let footerEl = $state<HTMLElement>();
+
   let {
     value = $bindable(true),
     bordered = false,
@@ -41,7 +43,7 @@
   const rightOffset = () => layoutView.value.charAt(10) === "r";
 
   $effect.pre(() => {
-    untrack(() => footerContext).updateEntries({ height, collapsed });
+    untrack(() => footerContext).updateEntries({ height, collapsed, ready: true });
   });
 
   onMount(() => {
@@ -49,10 +51,16 @@
     const content = document.querySelector(`.q-footer--${footerIdentifier} ~ .q-layout__content`);
 
     contentScrollHeight = content ? content.scrollHeight - content.clientHeight : 0;
+
+    setTimeout(() => {
+      if (footerEl) {
+        footerEl.style.transition = "all 0.3s";
+      }
+    }, 100);
   });
 
   onDestroy(() => {
-    untrack(() => footerContext).updateEntries({ height: 0, collapsed: false });
+    untrack(() => footerContext).updateEntries({ height: 0, collapsed: false, ready: false });
   });
 
   Q.classes("q-footer", {
@@ -68,7 +76,13 @@
 </script>
 
 {#if value}
-  <footer {...props} class="q-footer" style:--footer-height="{height}px" data-quaff>
+  <footer
+    bind:this={footerEl}
+    {...props}
+    class="q-footer"
+    style:--footer-height="{height}px"
+    data-quaff
+  >
     <QToolbar>
       {@render children?.()}
     </QToolbar>

--- a/src/lib/components/header/QHeader.scss
+++ b/src/lib/components/header/QHeader.scss
@@ -17,8 +17,6 @@
 
   background-color: var(--surface);
 
-  transition: all variables.$speed3;
-
   &.q-header--elevated {
     @include mixins.elevate(1);
   }

--- a/src/lib/components/header/QHeader.svelte
+++ b/src/lib/components/header/QHeader.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getContext, onDestroy, untrack } from "svelte";
+  import { getContext, onDestroy, onMount, untrack } from "svelte";
   import QToolbar from "$components/toolbar/QToolbar.svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
   import QScrollObserver from "$lib/classes/QScrollObserver.svelte";
@@ -19,6 +19,8 @@
     ...props
   }: QHeaderProps = $props();
 
+  let headerEl: HTMLElement;
+
   const headerContext = QContext.get<AppbarContext>("QHeader");
   const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>("view");
   if (!headerContext || !layoutView) {
@@ -36,11 +38,19 @@
   const rightOffset = () => layoutView.value.charAt(2) === "r";
 
   $effect.pre(() => {
-    untrack(() => headerContext).updateEntries({ height, collapsed });
+    untrack(() => headerContext).updateEntries({ height, collapsed, ready: true });
+  });
+
+  onMount(() => {
+    if (headerContext) {
+      setTimeout(() => {
+        headerEl.style.transition = "all 0.3s";
+      }, 100);
+    }
   });
 
   onDestroy(() => {
-    untrack(() => headerContext).updateEntries({ height: 0, collapsed: false });
+    untrack(() => headerContext).updateEntries({ height: 0, collapsed: false, ready: false });
   });
 
   Q.classes("q-header", {
@@ -56,7 +66,13 @@
   });
 </script>
 
-<header {...props} class="q-header" style:--header-height="{height}px" data-quaff>
+<header
+  bind:this={headerEl}
+  {...props}
+  class="q-header"
+  style:--header-height="{height}px"
+  data-quaff
+>
   <QToolbar {inset}>
     {@render children?.()}
   </QToolbar>

--- a/src/lib/components/layout/QLayout.scss
+++ b/src/lib/components/layout/QLayout.scss
@@ -14,14 +14,15 @@
   overflow: hidden;
 
   border-radius: inherit;
+  opacity: 0;
+
+  &.q-layout--ready {
+    opacity: 1;
+  }
 }
 
 .q-layout > .q-railbar {
   position: absolute;
-
-  transition:
-    top variables.$speed3,
-    bottom variables.$speed3;
 
   &.q-railbar--offset-top {
     // Put the railbar under the header to avoid hiding its box-shadow
@@ -77,11 +78,6 @@
 
 .q-layout > .q-drawer {
   border-radius: 0;
-
-  transition:
-    top variables.$speed3,
-    bottom variables.$speed3,
-    transform variables.$speed3;
 
   &.q-drawer--offset-top {
     // Put the railbar under the header to avoid hiding its box-shadow
@@ -175,5 +171,4 @@
 .q-layout > .q-layout__content {
   height: calc(100% - var(--offset-top) - var(--offset-bottom));
   overflow: auto;
-  transition: margin variables.$speed3;
 }

--- a/src/lib/components/layout/QLayout.svelte
+++ b/src/lib/components/layout/QLayout.svelte
@@ -7,11 +7,13 @@
   export interface AppbarContext {
     height: number;
     collapsed: boolean;
+    ready: boolean;
   }
 
   export interface DrawerContext {
     width: number;
     takesSpace: boolean;
+    ready: boolean;
   }
 </script>
 
@@ -31,10 +33,6 @@
     ...props
   }: QLayoutProps = $props();
 
-  Q.classes("q-layout", {
-    classes: [props.class],
-  });
-
   setContext("view", {
     get value() {
       return view;
@@ -44,29 +42,35 @@
   const headerCtx = new QContext<AppbarContext>("QHeader", {
     height: 0,
     collapsed: false,
+    ready: false,
   });
 
   const footerCtx = new QContext<AppbarContext>("QFooter", {
     height: 0,
     collapsed: false,
+    ready: false,
   });
 
   const leftRailbarCtx = new QContext<DrawerContext>("QRailbar-left", {
     width: 0,
     takesSpace: false,
+    ready: false,
   });
   const rightRailbarCtx = new QContext<DrawerContext>("QRailbar-right", {
     width: 0,
     takesSpace: false,
+    ready: false,
   });
 
   const leftDrawerCtx = new QContext<DrawerContext>("QDrawer-left", {
     width: 0,
     takesSpace: false,
+    ready: false,
   });
   const rightDrawerCtx = new QContext<DrawerContext>("QDrawer-right", {
     width: 360,
     takesSpace: false,
+    ready: false,
   });
 
   const topOffset = $derived(!header || headerCtx.value.collapsed ? 0 : headerCtx.value.height);
@@ -78,9 +82,25 @@
     `${header ? topOffset : 0}px ${rightOffset}px ${footer ? bottomOffset : 0}px ${leftOffset}px`
   );
 
+  const isReady = $derived(
+    (!header || headerCtx.value.ready) &&
+      (!footer || footerCtx.value.ready) &&
+      (!railbarLeft || leftRailbarCtx.value.ready) &&
+      (!railbarRight || rightRailbarCtx.value.ready) &&
+      (!drawerLeft || leftDrawerCtx.value.ready) &&
+      (!drawerRight || rightDrawerCtx.value.ready)
+  );
+
   function handleDrawerCtx(ctx: QContext<DrawerContext>) {
     return ctx.value.takesSpace ? ctx.value.width : 0;
   }
+
+  Q.classes("q-layout", {
+    bemClasses: {
+      ready: isReady,
+    },
+    classes: [props.class],
+  });
 </script>
 
 <div

--- a/src/lib/components/railbar/QRailbar.svelte
+++ b/src/lib/components/railbar/QRailbar.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { getContext, onDestroy, untrack } from "svelte";
+  import { getContext, onDestroy, onMount, untrack } from "svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
   import type { QLayoutProps } from "$components/layout/props";
   import type { DrawerContext } from "../layout/QLayout.svelte";
@@ -10,12 +10,21 @@
   const railbarCtx = QContext.get<DrawerContext>(`QRailbar-${side}`);
   const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>("view");
 
-  let railbarEl = $state<HTMLElement>();
+  let railbarEl: HTMLElement;
+
+  onMount(() => {
+    if (railbarCtx) {
+      setTimeout(() => {
+        railbarEl.style.transition = "top 0.3s, bottom 0.3s, transform 0.3s";
+      }, 100);
+    }
+  });
 
   onDestroy(() => {
     untrack(() => railbarCtx)?.updateEntries({
       width: 0,
       takesSpace: false,
+      ready: false,
     });
   });
 
@@ -23,6 +32,7 @@
     untrack(() => railbarCtx)?.updateEntries({
       width,
       takesSpace: railbarEl?.style.display !== "none" || false,
+      ready: true,
     });
   });
 


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix (kinda)
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Add CSS transition after the layout components are initially loaded to avoid unwanted movements

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
