### PR TITLE
refactor: use symbols instead of strings for context names

### DIFF
--- a/src/lib/classes/QContext.svelte.ts
+++ b/src/lib/classes/QContext.svelte.ts
@@ -9,28 +9,28 @@ import { getContext, setContext } from "svelte";
 export class QContext<T> {
   #state = $state<T>();
 
-  constructor(contextName: string, init: T) {
+  constructor(contextSymbol: symbol, init: T) {
     this.#state = init;
 
-    setContext(contextName, this);
+    setContext(contextSymbol, this);
   }
 
   /**
-   * Gets the value of context with id `contextName`
-   * @param contextName - Name of the context to get
+   * Gets the value of context with id `contextSymbol`
+   * @param contextSymbol - Name of the context to get
    * @returns The context's value
    */
-  static get<T>(contextName: string) {
-    return getContext<QContext<T> | undefined>(contextName);
+  static get<T>(contextSymbol: symbol) {
+    return getContext<QContext<T> | undefined>(contextSymbol);
   }
 
   /**
    * Prevents the propagation of the context further down
-   * @param contextName - Name of the context to get
+   * @param contextSymbol - Name of the context to get
    * @returns The context result
    */
-  static reset(contextName: string) {
-    setContext(contextName, undefined);
+  static reset(contextSymbol: symbol) {
+    setContext(contextSymbol, undefined);
   }
 
   /**

--- a/src/lib/components/breadcrumbs/QBreadcrumbs.svelte
+++ b/src/lib/components/breadcrumbs/QBreadcrumbs.svelte
@@ -2,6 +2,7 @@
 
 <script lang="ts">
   import { setContext, untrack } from "svelte";
+  import { QBreadcrumbsCtxName } from "$utils/context";
   import type { QBreadcrumbsProps } from "./props";
 
   let {
@@ -19,8 +20,8 @@
     untrack(() => breadrumbElement.firstChild?.remove());
   });
 
-  setContext("activeColor", activeColor);
-  setContext("separator", { type: separator, color: separatorColor, gutter });
+  setContext(QBreadcrumbsCtxName.activeColor, activeColor);
+  setContext(QBreadcrumbsCtxName.separator, { type: separator, color: separatorColor, gutter });
 
   Q.classes("q-breadcrumbs", { classes: [props.class] });
 </script>

--- a/src/lib/components/breadcrumbs/QBreadcrumbsEl.svelte
+++ b/src/lib/components/breadcrumbs/QBreadcrumbsEl.svelte
@@ -3,6 +3,7 @@
 <script lang="ts">
   import { getContext, type Snippet } from "svelte";
   import { isRouteActive } from "$utils/router";
+  import { QBreadcrumbsCtxName } from "$utils/context";
   import QIcon from "../icon/QIcon.svelte";
   import type { MaterialSymbol } from "material-symbols";
   import type { QBreadcrumbsElProps } from "./props";
@@ -18,12 +19,12 @@
     ...props
   }: QBreadcrumbsElProps = $props();
 
-  const activeColor = getContext<string>("activeColor");
+  const activeColor = getContext<string>(QBreadcrumbsCtxName.activeColor);
   const separator = getContext<{
     type: `icon:${MaterialSymbol}` | Snippet;
     color: string;
     gutter: string;
-  }>("separator");
+  }>(QBreadcrumbsCtxName.separator);
 
   const classesIfActive = $derived(
     isRouteActive(href || to) ? `${activeClass} text-${activeColor}` : undefined

--- a/src/lib/components/drawer/QDrawer.svelte
+++ b/src/lib/components/drawer/QDrawer.svelte
@@ -3,6 +3,7 @@
   import { navigating } from "$app/state";
   import { useSize } from "$lib/composables";
   import { QContext } from "$lib/classes/QContext.svelte";
+  import { QLayoutCtxName } from "$utils/context";
   import type { QLayoutProps } from "$components/layout/props";
   import type { DrawerContext } from "../layout/QLayout.svelte";
   import type { QDrawerProps } from "./props";
@@ -20,8 +21,8 @@
 
   let drawerEl: HTMLDivElement;
 
-  const drawerContext = QContext.get<DrawerContext>(`QDrawer-${side}`);
-  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>("view");
+  const drawerContext = QContext.get<DrawerContext>(QLayoutCtxName.drawer[side]);
+  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>(QLayoutCtxName.view);
 
   const canHideOnClickOutside = $derived((value && !persistent) || overlay);
 

--- a/src/lib/components/footer/QFooter.svelte
+++ b/src/lib/components/footer/QFooter.svelte
@@ -2,8 +2,9 @@
   import { getContext, onDestroy, onMount, untrack } from "svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
   import QScrollObserver from "$lib/classes/QScrollObserver.svelte";
-  import type { QLayoutProps } from "$components/layout/props";
   import QToolbar from "$components/toolbar/QToolbar.svelte";
+  import { QLayoutCtxName } from "$utils/context";
+  import type { QLayoutProps } from "$components/layout/props";
   import type { AppbarContext } from "../layout/QLayout.svelte";
   import type { QFooterProps } from "./props";
 
@@ -21,8 +22,8 @@
 
   const uid = $props.id();
 
-  const footerContext = QContext.get<AppbarContext>("QFooter");
-  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>("view");
+  const footerContext = QContext.get<AppbarContext>(QLayoutCtxName.footer);
+  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>(QLayoutCtxName.view);
 
   if (!footerContext || !layoutView) {
     throw new Error("QFooter should be used inside QLayout");

--- a/src/lib/components/header/QHeader.svelte
+++ b/src/lib/components/header/QHeader.svelte
@@ -3,6 +3,7 @@
   import QToolbar from "$components/toolbar/QToolbar.svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
   import QScrollObserver from "$lib/classes/QScrollObserver.svelte";
+  import { QLayoutCtxName } from "$utils/context";
   import type { AppbarContext } from "$components/layout/QLayout.svelte";
   import type { QLayoutProps } from "$components/layout/props";
   import type { QHeaderProps } from "./props";
@@ -21,8 +22,8 @@
 
   let headerEl: HTMLElement;
 
-  const headerContext = QContext.get<AppbarContext>("QHeader");
-  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>("view");
+  const headerContext = QContext.get<AppbarContext>(QLayoutCtxName.header);
+  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>(QLayoutCtxName.view);
   if (!headerContext || !layoutView) {
     throw new Error("QHeader should be used inside QLayout");
   }

--- a/src/lib/components/layout/QLayout.svelte
+++ b/src/lib/components/layout/QLayout.svelte
@@ -1,6 +1,7 @@
 <script module lang="ts">
   import { onMount, setContext } from "svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
+  import { QLayoutCtxName } from "$utils/context";
   import ContextReseter from "../private/ContextReseter.svelte";
   import type { QLayoutProps } from "./props";
 
@@ -41,41 +42,41 @@
     }, 100);
   });
 
-  setContext("view", {
+  setContext(QLayoutCtxName.view, {
     get value() {
       return view;
     },
   });
 
-  const headerCtx = new QContext<AppbarContext>("QHeader", {
+  const headerCtx = new QContext<AppbarContext>(QLayoutCtxName.header, {
     height: 0,
     collapsed: false,
     ready: false,
   });
 
-  const footerCtx = new QContext<AppbarContext>("QFooter", {
+  const footerCtx = new QContext<AppbarContext>(QLayoutCtxName.footer, {
     height: 0,
     collapsed: false,
     ready: false,
   });
 
-  const leftRailbarCtx = new QContext<DrawerContext>("QRailbar-left", {
+  const leftRailbarCtx = new QContext<DrawerContext>(QLayoutCtxName.railbar.left, {
     width: 0,
     takesSpace: false,
     ready: false,
   });
-  const rightRailbarCtx = new QContext<DrawerContext>("QRailbar-right", {
+  const rightRailbarCtx = new QContext<DrawerContext>(QLayoutCtxName.railbar.right, {
     width: 0,
     takesSpace: false,
     ready: false,
   });
 
-  const leftDrawerCtx = new QContext<DrawerContext>("QDrawer-left", {
+  const leftDrawerCtx = new QContext<DrawerContext>(QLayoutCtxName.drawer.left, {
     width: 0,
     takesSpace: false,
     ready: false,
   });
-  const rightDrawerCtx = new QContext<DrawerContext>("QDrawer-right", {
+  const rightDrawerCtx = new QContext<DrawerContext>(QLayoutCtxName.drawer.right, {
     width: 360,
     takesSpace: false,
     ready: false,
@@ -134,12 +135,12 @@
 
   <ContextReseter
     keys={[
-      "QHeader",
-      "QFooter",
-      "QRailbar-left",
-      "QRailbar-right",
-      "QDrawer-left",
-      "QDrawer-right",
+      QLayoutCtxName.header,
+      QLayoutCtxName.footer,
+      QLayoutCtxName.railbar.left,
+      QLayoutCtxName.railbar.right,
+      QLayoutCtxName.drawer.left,
+      QLayoutCtxName.drawer.right,
     ]}
   >
     <div bind:this={contentEl} class="q-layout__content" style:margin={contentMargin}>

--- a/src/lib/components/list/QItem.svelte
+++ b/src/lib/components/list/QItem.svelte
@@ -3,6 +3,7 @@
   import { getRouterInfo, isRouteActive } from "$lib/utils/router";
   import { ripple } from "$lib/helpers/ripple";
   import { QContext } from "$lib/classes/QContext.svelte";
+  import { QItemCtxName, QListCtxName } from "$utils/context";
   import QSeparator from "../separator/QSeparator.svelte";
   import type { QItemProps, QListProps } from "./props";
 
@@ -32,17 +33,19 @@
     })
   );
 
-  const listActiveClass = getContext<() => string>("listItemsActiveClass");
+  const listActiveClass = getContext<() => string>(QListCtxName.activeClass);
 
   const activeClassToUse = $derived(
     activeClass === "active" ? listActiveClass() || activeClass : activeClass
   );
 
-  setContext("itemActiveClass", () => active && activeClassToUse);
+  setContext(QItemCtxName.activeClass, () => active && activeClassToUse);
 
-  const multiline = new QContext("multiline", false);
+  const multiline = new QContext(QItemCtxName.multiline, false);
 
-  const separatorOptions = getContext<QListProps["separatorOptions"] | undefined>("separator");
+  const separatorOptions = getContext<QListProps["separatorOptions"] | undefined>(
+    QListCtxName.separator
+  );
 
   const isActionable = $derived(clickable || routerInfo.hasLink || tag === "label");
   const isClickable = $derived(isActionable && !disabled);

--- a/src/lib/components/list/QItemSection.svelte
+++ b/src/lib/components/list/QItemSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getContext, type Snippet } from "svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
+  import { QItemCtxName } from "$utils/context";
   import type { QItemSectionProps } from "./props";
 
   let {
@@ -13,9 +14,9 @@
     ...props
   }: QItemSectionProps = $props();
 
-  const activeClass = getContext<() => string>("itemActiveClass");
+  const activeClass = getContext<() => string>(QItemCtxName.activeClass);
 
-  const multiline = QContext.get<boolean>("multiline");
+  const multiline = QContext.get<boolean>(QItemCtxName.multiline);
 
   $effect(() => {
     if (type === "content") {

--- a/src/lib/components/list/QList.svelte
+++ b/src/lib/components/list/QList.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { setContext } from "svelte";
+  import { QListCtxName } from "$utils/context";
   import type { QListProps } from "./props";
 
   let {
@@ -15,15 +16,14 @@
     ...props
   }: QListProps = $props();
 
-  setContext("listItemsActiveClass", () => activeClass);
+  setContext(QListCtxName.activeClass, () => activeClass);
+  setContext(QListCtxName.separator, separator ? separatorOptions : undefined);
 
   let listEl: HTMLElement;
 
   $effect(() => {
     listEl.querySelector(".q-separator__wrapper:first-child")?.remove();
   });
-
-  setContext("separator", separator ? separatorOptions : undefined);
 
   Q.classes("q-list", {
     bemClasses: {

--- a/src/lib/components/private/ContextReseter.svelte
+++ b/src/lib/components/private/ContextReseter.svelte
@@ -6,7 +6,7 @@
     keys,
     children,
   }: {
-    keys: string | string[];
+    keys: symbol | symbol[];
     children?: Snippet;
   } = $props();
 

--- a/src/lib/components/private/QDocs.svelte
+++ b/src/lib/components/private/QDocs.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
   import { setContext, type Snippet } from "svelte";
+  import { assets } from "$app/paths";
   import { QCard, QCardSection } from "$lib";
   import type { QComponentDocs } from "$lib/utils";
   import Quaff from "$lib/classes/Quaff.svelte";
-  import { assets } from "$app/paths";
+  import { QDocsCtxName } from "$utils/context";
   import QApi from "./QApi.svelte";
 
   let {
@@ -29,7 +30,7 @@
   const isDark = $derived(Quaff.darkMode.isActive);
 
   if (snippets) {
-    setContext("QDocsSnippets", () => snippets);
+    setContext(QDocsCtxName.snippets, () => snippets);
   }
 
   let image = $state<string>();

--- a/src/lib/components/private/QDocsSection.svelte
+++ b/src/lib/components/private/QDocsSection.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import { getContext, type Snippet } from "svelte";
   import { QCodeBlock, QDialog, QBtn } from "$lib";
+  import { QDocsCtxName } from "$utils/context";
 
   type QDocsSectionProps = {
     title: string;
@@ -11,7 +12,7 @@
 
   let { title, noCode = false, sectionDescription, children }: QDocsSectionProps = $props();
 
-  const snippets = getContext<undefined | (() => Record<string, string>)>("QDocsSnippets");
+  const snippets = getContext<undefined | (() => Record<string, string>)>(QDocsCtxName.snippets);
 
   const code = $derived(snippets && snippets()[title]);
 

--- a/src/lib/components/railbar/QRailbar.svelte
+++ b/src/lib/components/railbar/QRailbar.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
   import { getContext, onDestroy, onMount, untrack } from "svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
+  import { QLayoutCtxName } from "$utils/context";
   import type { QLayoutProps } from "$components/layout/props";
   import type { DrawerContext } from "../layout/QLayout.svelte";
   import type { QRailbarProps } from "./props";
 
   let { width = 88, side = "left", bordered = false, children, ...props }: QRailbarProps = $props();
 
-  const railbarCtx = QContext.get<DrawerContext>(`QRailbar-${side}`);
-  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>("view");
+  const railbarCtx = QContext.get<DrawerContext>(QLayoutCtxName.railbar[side]);
+  const layoutView = getContext<{ value: NonNullable<QLayoutProps["view"]> }>(QLayoutCtxName.view);
 
   let railbarEl: HTMLElement;
 

--- a/src/lib/components/tabs/QTab.svelte
+++ b/src/lib/components/tabs/QTab.svelte
@@ -4,9 +4,10 @@
   import { QContext } from "$lib/classes/QContext.svelte";
   import { ripple } from "$lib/helpers";
   import { getClosestFocusableBlock, getClosestFocusableSibling } from "$lib/utils/dom";
-  import type { Direction } from "$lib/utils/events";
   import { getDirection, isActivationKey, isArrowKey, isTabKey } from "$lib/utils/events";
   import { isRouteActive } from "$lib/utils/router";
+  import { QTabsCtxName } from "$utils/context";
+  import type { Direction } from "$lib/utils/events";
   import type { QEvent } from "$utils/types";
   import type { QTabEl } from "./QTabs.svelte";
   import type { QTabProps, QTabsVariants } from "./props";
@@ -19,14 +20,14 @@
 
   const tag = $derived(to ? "a" : "button");
 
-  if (!hasContext("QTabsValue")) {
+  if (!hasContext(QTabsCtxName.value)) {
     console.warn("QTab should be use inside QTabs.");
   }
 
-  const qTabsRequestCtx = QContext.get<string | null>("QTabsRequest")!;
+  const qTabsRequestCtx = QContext.get<string | null>(QTabsCtxName.request)!;
 
-  const qTabsValueCtx = QContext.get<string | undefined | null>("QTabsValue")!;
-  const variant = getContext<QTabsVariants>("QTabsVariant");
+  const qTabsValueCtx = QContext.get<string | undefined | null>(QTabsCtxName.value)!;
+  const variant = getContext<QTabsVariants>(QTabsCtxName.variant);
   const isActive = $derived(to ? isRouteActive(to) : name === qTabsValueCtx.value);
 
   function onclick(e: QTabEvent<MouseEvent>) {

--- a/src/lib/components/tabs/QTabs.svelte
+++ b/src/lib/components/tabs/QTabs.svelte
@@ -10,6 +10,7 @@
   import { setContext, untrack } from "svelte";
   import { QContext } from "$lib/classes/QContext.svelte";
   import { shouldReduceMotion } from "$lib/utils/dom";
+  import { QTabsCtxName } from "$utils/context";
   import type { QTabsProps } from "./props";
 
   let {
@@ -23,11 +24,11 @@
   let qTabs: HTMLElement;
   let tabList: HTMLElement[];
 
-  const valueContext = new QContext<string | undefined | null>("QTabsValue", value);
-  const requestContext = new QContext<string | null>("QTabsRequest", null);
+  const valueContext = new QContext<string | undefined | null>(QTabsCtxName.value, value);
+  const requestContext = new QContext<string | null>(QTabsCtxName.request, null);
 
   // Set the variant context
-  setContext("QTabsVariant", variant);
+  setContext(QTabsCtxName.variant, variant);
 
   $effect(() => {
     tabList = Array.from(qTabs.querySelectorAll(".q-tab"));

--- a/src/lib/utils/context.ts
+++ b/src/lib/utils/context.ts
@@ -1,0 +1,38 @@
+export const QBreadcrumbsCtxName = {
+  activeColor: Symbol("activeColor"),
+  separator: Symbol("separator"),
+};
+
+export const QDocsCtxName = {
+  snippets: Symbol("snippets"),
+};
+
+export const QItemCtxName = {
+  activeClass: Symbol("activeClass"),
+  multiline: Symbol("multiline"),
+};
+
+export const QLayoutCtxName = {
+  view: Symbol("layoutView"),
+  header: Symbol("QHeader"),
+  footer: Symbol("QFooter"),
+  railbar: {
+    left: Symbol("QRailbar-left"),
+    right: Symbol("QRailbar-right"),
+  },
+  drawer: {
+    left: Symbol("QDrawer-left"),
+    right: Symbol("QDrawer-right"),
+  },
+};
+
+export const QListCtxName = {
+  activeClass: Symbol("activeClass"),
+  separator: Symbol("separator"),
+};
+
+export const QTabsCtxName = {
+  request: Symbol("request"),
+  value: Symbol("value"),
+  variant: Symbol("variant"),
+};


### PR DESCRIPTION
As mentionned in #113, this is to avoid potential private API leakage.

## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix (potentially)
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Use globally exported symbols for context names instead of simple strings

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

Closes #113 
