### PR TITLE
fix: remove and replace "surface-variant" color

### DIFF
--- a/src/lib/css/shared/q-field.scss
+++ b/src/lib/css/shared/q-field.scss
@@ -83,7 +83,7 @@
   }
 
   &--filled &__wrapper {
-    background-color: var(--surface-variant);
+    background-color: var(--surface-container);
     border-top-left-radius: 0.25rem;
     border-top-right-radius: 0.25rem;
   }

--- a/src/lib/css/theme/_color-classes.scss
+++ b/src/lib/css/theme/_color-classes.scss
@@ -228,15 +228,6 @@
   @extend .text-on-surface;
 }
 
-.bg-surface-variant {
-  background-color: var(--surface-variant) !important;
-}
-.text-surface-variant {
-  color: var(--surface-variant) !important;
-}
-.border-surface-variant {
-  border-color: var(--surface-variant) !important;
-}
 .bg-on-surface-variant {
   background-color: var(--on-surface-variant) !important;
 }
@@ -245,10 +236,6 @@
 }
 .border-on-surface-variant {
   border-color: var(--on-surface-variant) !important;
-}
-.surface-variant {
-  @extend .bg-surface-variant;
-  @extend .text-on-surface-variant;
 }
 
 .bg-outline {


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## What's new?

> List the changes

- replace `--surface-variant` color and remove associated classes

This fixes the `filled` variant of `QInput` and `QSelect`.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
