### PR TITLE
refactor: add a srcColor property on QTheme

### DIFF
--- a/src/lib/classes/QTheme.svelte.ts
+++ b/src/lib/classes/QTheme.svelte.ts
@@ -33,9 +33,10 @@ function prepareThemeColors(from: string) {
 
 class QTheme {
   themeColors = $state({} as ThemeColors);
+  srcColor = $state("#0039b4");
 
   constructor() {
-    this.themeColors = prepareThemeColors("#0039b4");
+    this.themeColors = prepareThemeColors(this.srcColor);
   }
 
   private apply() {
@@ -71,6 +72,7 @@ class QTheme {
   setTheme(from: string) {
     const newTheme = prepareThemeColors(from);
     this.themeColors = newTheme;
+    this.srcColor = from;
     this.apply();
   }
 }


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## What's new?

> List the changes

- Add a `srcColor` property on QTheme to keep track of the theme source color

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
