### PR TITLE
fix: QLayout so users can use their own layout elements

### DIFF
--- a/src/lib/components/layout/QLayout.svelte
+++ b/src/lib/components/layout/QLayout.svelte
@@ -34,6 +34,7 @@
     ...props
   }: QLayoutProps = $props();
 
+  let layoutEl = $state<HTMLDivElement>();
   let contentEl: HTMLDivElement;
 
   onMount(() => {
@@ -92,12 +93,20 @@
   );
 
   const isReady = $derived(
-    (!header || headerCtx.value.ready) &&
-      (!footer || footerCtx.value.ready) &&
-      (!railbarLeft || leftRailbarCtx.value.ready) &&
-      (!railbarRight || rightRailbarCtx.value.ready) &&
-      (!drawerLeft || leftDrawerCtx.value.ready) &&
-      (!drawerRight || rightDrawerCtx.value.ready)
+    (!header || headerCtx.value.ready || (layoutEl && !layoutEl.querySelector(".q-header"))) &&
+      (!footer || footerCtx.value.ready || (layoutEl && !layoutEl.querySelector(".q-footer"))) &&
+      (!railbarLeft ||
+        leftRailbarCtx.value.ready ||
+        (layoutEl && !layoutEl.querySelector(".q-railbar--left"))) &&
+      (!railbarRight ||
+        rightRailbarCtx.value.ready ||
+        (layoutEl && !layoutEl.querySelector(".q-railbar--right"))) &&
+      (!drawerLeft ||
+        leftDrawerCtx.value.ready ||
+        (layoutEl && !layoutEl.querySelector(".q-drawer--left"))) &&
+      (!drawerRight ||
+        rightDrawerCtx.value.ready ||
+        (layoutEl && !layoutEl.querySelector(".q-drawer--right")))
   );
 
   function handleDrawerCtx(ctx: QContext<DrawerContext>) {
@@ -113,6 +122,7 @@
 </script>
 
 <div
+  bind:this={layoutEl}
   {...props}
   class="q-layout"
   style:--left-drawer-width={`${drawerLeft ? leftDrawerCtx.value.width : 0}px`}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -285,7 +285,7 @@
     </QDrawer>
   {/snippet}
   {#snippet content()}
-    <div bind:this={contentEl} style="position: relative; min-height: 100%">
+    <div bind:this={contentEl} style="position: relative; min-height: 100%; padding-top: 10%">
       {@render children?.()}
       <div class="privacy-policy"><a href="{base}/privacy-policy">Privacy Policy</a></div>
     </div>


### PR DESCRIPTION
And add padding to +layout.svelte

## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Change the layout ready state to allow users to use their own layout elements and not Quaff elements
- Add top padding to home landing page elements

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
