### PR TITLE
fix: wrap `%svetekit.body%` in a `div` and improve some style

### DIFF
--- a/src/app.html
+++ b/src/app.html
@@ -24,6 +24,7 @@
         }
       }
     </script>
-    %sveltekit.body%
+
+    <div>%sveltekit.body%</div>
   </body>
 </html>

--- a/src/lib/css/theme/_reset.scss
+++ b/src/lib/css/theme/_reset.scss
@@ -17,7 +17,8 @@ body {
   background-color: var(--surface);
 }
 
-body {
+body,
+body > div {
   background-color: var(--surface-container-lowest);
   overflow-x: hidden;
   height: 100vh;

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -358,7 +358,7 @@
 
     <QCardActions align="right">
       <QBtn label="Cancel" variant="flat" />
-      <QBtn label="Delete" class="error" />
+      <QBtn label="Delete" class="error-container" />
     </QCardActions>
   </QCard>
 {/snippet}


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix?
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Try to fix the problem some users face (nothing styled) by wrapping `%sveltekit.body%` in a `div` like recommended by Svelte
- Use `error-container` instead of `error` for a button in a component card

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
