### PR TITLE
fix: QTooltip styles broken by _reset.scss

### DIFF
--- a/src/lib/components/tooltip/QTooltip.svelte
+++ b/src/lib/components/tooltip/QTooltip.svelte
@@ -31,7 +31,7 @@
   let tooltipMouseLeaveListener: ReturnType<typeof addEventListener> | null = null;
   let windowWheelListener: ReturnType<typeof addEventListener> | null = null;
 
-  const id = Date.now();
+  const id = $props.id();
 
   $effect(() => {
     value ? untrack(show) : untrack(hide);
@@ -102,7 +102,7 @@
       timerShow = null;
       mountedTooltip = mountTooltip();
 
-      tooltipEl = (document.getElementById(`qtooltip-${id}`) as HTMLDivElement) || undefined;
+      tooltipEl = (document.getElementById(`q-tooltip-${id}`) as HTMLDivElement) || undefined;
       tooltipMouseEnterListener = addEventListener(tooltipEl, "mouseenter", abortHide);
       tooltipMouseLeaveListener = addEventListener(tooltipEl, "mouseleave", hide);
 
@@ -177,7 +177,7 @@
         position,
         offset,
         children,
-        id: `qtooltip-${id}`,
+        id: `q-tooltip-${id}`,
         ...props,
       },
     });

--- a/src/lib/css/theme/_reset.scss
+++ b/src/lib/css/theme/_reset.scss
@@ -18,7 +18,7 @@ body {
 }
 
 body,
-body > div {
+body > div:not(.q-tooltip) {
   background-color: var(--surface-container-lowest);
   overflow-x: hidden;
   height: 100vh;


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Change _reset.scss to not break QTooltips attached to body

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
