### PR TITLE
feat: add support for select object options

### DIFF
--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -36,15 +36,15 @@
       return displayValue;
     }
 
-    const fn = emitValue ? getOptionValue : getOptionLabel;
+    const getOptionPropFn = emitValue ? getOptionValue : getOptionLabel;
 
     if (!multiple) {
-      return fn(value as QSelectOption);
+      return getOptionPropFn(value as QSelectOption);
     }
 
     return (value as QSelectOption[])
       .map((val) => {
-        return fn(val);
+        return getOptionPropFn(val);
       })
       .join(", ");
   });

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -123,7 +123,7 @@
       if (index !== -1) {
         (value as QSelectOption[]).splice(index, 1);
       } else {
-        (value as QSelectOption[]).push(optionValue);
+        (value as QSelectOption[]).push(emitValue ? optionValue : option);
       }
 
       return;

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -86,25 +86,29 @@
 
   let snippetPrependWidth = $state(0);
 
-  function getOptionValue(option: QSelectOption): string {
-    return typeof option === "string" ? option : option.value;
+  function compareValues<T extends QSelectOption>(a: T, b: T) {
+    return getOptionValue(a) === getOptionValue(b);
   }
 
-  function getOptionLabel(option: QSelectOption): string {
-    if (typeof option !== "string") {
+  function getOptionValue(option: QSelectOption) {
+    return typeof option === "object" ? option.value : option;
+  }
+
+  function getOptionLabel(option: QSelectOption) {
+    if (typeof option !== "string" && typeof option !== "number") {
       return option.label;
     }
 
     return options.includes(option)
       ? option
-      : (options.find((opt) => getOptionValue(opt) === option) as { label: string })?.label || "";
+      : (options.find((opt) => compareValues(opt, option)) as { label: string | number })?.label ||
+          "";
   }
 
   function isSelected(option: QSelectOption) {
-    const optionValue = getOptionValue(option);
     return multiple
-      ? (value as QSelectOption[]).some((opt) => getOptionValue(opt) === optionValue)
-      : getOptionValue(value as QSelectOption) === optionValue;
+      ? (value as QSelectOption[]).some((opt) => compareValues(opt, option))
+      : compareValues(value as QSelectOption, option);
   }
 
   function select(evt: MouseEvent, option: QSelectOption) {
@@ -112,14 +116,14 @@
     const optionValue = getOptionValue(option);
 
     if (multiple) {
-      const hasItem = (value as QSelectOption[]).some((entry) => entry === optionValue);
+      const index = (value as QSelectOption[]).findIndex((entry) =>
+        compareValues(entry, optionValue)
+      );
 
-      if (hasItem) {
-        (value as QSelectOption[]) = (value as QSelectOption[]).filter(
-          (val) => val !== optionValue
-        );
+      if (index !== -1) {
+        (value as QSelectOption[]).splice(index, 1);
       } else {
-        (value as QSelectOption[]) = [...(value as QSelectOption[]), optionValue];
+        (value as QSelectOption[]).push(optionValue);
       }
 
       return;

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -42,7 +42,7 @@
       return getOptionPropFn(value as QSelectOption);
     }
 
-    return (value as QSelectOption[]).map((val) => getOptionPropFn(val)).join(", ");
+    return (value as QSelectOption[]).map(getOptionPropFn).join(", ");
   });
 
   const active = $derived(currentDisplayValue || focus);

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -42,11 +42,7 @@
       return getOptionPropFn(value as QSelectOption);
     }
 
-    return (value as QSelectOption[])
-      .map((val) => {
-        return getOptionPropFn(val);
-      })
-      .join(", ");
+    return (value as QSelectOption[]).map((val) => getOptionPropFn(val)).join(", ");
   });
 
   const active = $derived(currentDisplayValue || focus);

--- a/src/lib/components/select/props.ts
+++ b/src/lib/components/select/props.ts
@@ -2,7 +2,7 @@ import type { NativeProps } from "$utils";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 
-export type QSelectOption = string | { label: string; value: string };
+export type QSelectOption = string | number | { label: string | number; value: string | number };
 
 export type QSelectValue = QSelectOption | QSelectOption[];
 

--- a/src/lib/components/select/props.ts
+++ b/src/lib/components/select/props.ts
@@ -4,11 +4,7 @@ import type { HTMLAttributes } from "svelte/elements";
 
 export type QSelectOption = string | { label: string; value: string };
 
-export type QSelectValue = QSelectSingleValue | QSelectMultipleValue;
-
-export type QSelectSingleValue = string | number;
-
-export type QSelectMultipleValue = QSelectSingleValue[];
+export type QSelectValue = QSelectOption | QSelectOption[];
 
 export interface QSelectProps extends NativeProps, HTMLAttributes<HTMLDivElement> {
   /**
@@ -100,6 +96,13 @@ export interface QSelectProps extends NativeProps, HTMLAttributes<HTMLDivElement
    * @default undefined
    */
   displayValue?: string;
+
+  /**
+   * Indicates whether to emit the value rather than the entire option object when a value is selected.
+   *
+   * @default false
+   */
+  emitValue?: boolean;
 
   /**
    * Content to be placed before the select wrapper element, usually an icon.

--- a/src/lib/components/table/QTable.svelte
+++ b/src/lib/components/table/QTable.svelte
@@ -18,13 +18,14 @@
 
   let page = $state(1);
   let rowsPerPage = $state(5);
-  let rowsPerPageOptions = $state(
-    [5, 10, 25, 50].map((e) => ({
-      label: e.toString(),
-      value: e.toString(),
-    }))
-  );
+
   let sort: QTableSort = $state(null);
+
+  const rowsPerPageOptions = $derived(
+    [5, 10, 25, 50].filter((option) => {
+      return rows.length >= option || option === 5;
+    })
+  );
 
   const numberFrom: number = $derived(rowsPerPage * page - rowsPerPage + 1);
   const numberTo: number = $derived(
@@ -157,6 +158,7 @@
       outlined
       options={rowsPerPageOptions}
       bind:value={rowsPerPage}
+      disable={rowsPerPageOptions.length <= 1}
     />
     {numberFrom}-{numberTo}&nbsp;of&nbsp;{numberOf}
     <QBtn

--- a/src/routes/components/dialog/+page.svelte
+++ b/src/routes/components/dialog/+page.svelte
@@ -9,7 +9,7 @@
     QItem,
     QItemSection,
     QList,
-    QRadio,
+    QSelect,
   } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import type { QDialogPositionOptions } from "$components/dialog/props";
@@ -27,6 +27,13 @@
   let dialogRef = $state<QDialog>();
   let positionDialogRef = $state<QDialog>();
 
+  const options = [
+    { label: "Default (Center)", value: "default" },
+    { label: "Top", value: "top" },
+    { label: "Right", value: "right" },
+    { label: "Bottom", value: "bottom" },
+    { label: "Left", value: "left" },
+  ];
   let selectedPosition: QDialogPositionOptions = $state("default");
 </script>
 
@@ -126,17 +133,15 @@
           issues as the dialog doesn't have time to reposition before being visible.
         {/snippet}
 
-        <div class="q-ma-sm row">
-          <div class="col-3 flex column q-gap-md">
-            <QRadio bind:selected={selectedPosition} label="Default (Center)" value="default" />
-            <QRadio bind:selected={selectedPosition} label="Top" value="top" />
-            <QRadio bind:selected={selectedPosition} label="Right" value="right" />
-            <QRadio bind:selected={selectedPosition} label="Bottom" value="bottom" />
-            <QRadio bind:selected={selectedPosition} label="Left" value="left" />
-          </div>
-          <div class="col-9 flex items-center">
-            <QBtn label="Open Position Dialog" onclick={positionDialogRef?.toggle} />
-          </div>
+        <div class="q-ma-sm flex q-gap-md">
+          <QSelect
+            bind:value={selectedPosition}
+            {options}
+            label="Select Dialog Position"
+            outlined
+          />
+
+          <QBtn label="Open Position Dialog" onclick={positionDialogRef?.toggle} />
         </div>
 
         <QDialog bind:this={positionDialogRef} position={selectedPosition}>

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -3,6 +3,7 @@
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QCard, QCardActions, QCardSection, QIcon, QItem, QList, QSelect } from "$lib";
   import { QDocs, QDocsSection } from "$private";
+  import type { QSelectOption } from "$components/select/props";
   import snippets from "./docs.snippets";
 
   let selectDisabled = $state(true);
@@ -30,7 +31,8 @@
 
   let value = $state("");
   let select = $state("");
-  let colorSelect = $state("");
+  let colorSelect = $state<QSelectOption>("");
+  let colorSelectValue = $state("");
   let selectMultiple: string[] = $state([]);
 
   const displayValue = $derived.by(() => {
@@ -79,18 +81,50 @@
           value.
         {/snippet}
 
-        <div class="flex q-gap-md">
-          <div class="q-ma-sm" style="max-width: 300px;">
+        <div class="flex column q-gap-md">
+          <div class="q-ma-sm">
             <h6 class="q-mb-sm">String options</h6>
-            <QSelect bind:value={select} {options} label="Choose an animal" />
-            <div class="q-mt-sm">Selected: {select}</div>
+            <QSelect
+              bind:value={select}
+              {options}
+              label="Choose an animal"
+              style="max-width: 300px;"
+            />
+            <div class="q-mt-sm">Selected: {select || "None"}</div>
           </div>
 
-          <div class="q-ma-sm" style="max-width: 300px;">
+          <div class="q-ma-sm">
             <h6 class="q-mb-sm">Object options</h6>
-            <QSelect bind:value={colorSelect} options={objectOptions} label="Choose a color" />
+            <QSelect
+              bind:value={colorSelect}
+              options={objectOptions}
+              label="Choose a color"
+              style="max-width: 300px;"
+            />
             <div class="q-mt-sm">
-              Selected value: {colorSelect || "None"}
+              Selected value:
+              {(typeof colorSelect === "string"
+                ? colorSelect
+                : JSON.stringify(colorSelect, null, 1).replaceAll("\n", " ")) || "None"}
+            </div>
+          </div>
+
+          <div class="q-ma-sm">
+            <h6 class="q-mb-sm">Emit value</h6>
+            <p>
+              When using object options, use the <code>emitValue</code> prop to return the
+              <code>value</code> property instead of the entire object.
+            </p>
+            <QSelect
+              bind:value={colorSelectValue}
+              options={objectOptions}
+              label="Choose a color"
+              emitValue
+              style="max-width: 300px;"
+            />
+            <div class="q-mt-sm">
+              Selected value:
+              {colorSelectValue || "None"}
             </div>
           </div>
         </div>
@@ -196,9 +230,9 @@
 
       <QDocsSection title="Validation and Hints">
         {#snippet sectionDescription()}
-          QSelect provides built-in support for validation states and helper text. Use the <code
-            >error</code
-          >
+          QSelect provides built-in support for validation states and helper text. Use the <code>
+            error
+          </code>
           prop to indicate validation errors and <code>hint</code> to provide additional guidance to
           users.
         {/snippet}


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Simplify types for `QSelect`
- Allow binding to object value
- Options and input value show option label when using an object
- Add an `emitValue` prop to bind with value instead of the whole option object
- Update the select docs to show an example of the new feature
- Update dialog docs to use QSelect instead of QRadio buttons

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
