### PR TITLE
fix: fix ripple in elements that use it

### DIFF
--- a/src/lib/components/button/QBtn.scss
+++ b/src/lib/components/button/QBtn.scss
@@ -34,6 +34,8 @@
       variables.$speed3 border-radius,
       variables.$speed3 padding;
 
+    isolation: isolate;
+
     @include mixins.btn-image;
 
     $sizeMap: (

--- a/src/lib/components/chip/QChip.scss
+++ b/src/lib/components/chip/QChip.scss
@@ -19,6 +19,8 @@
     cursor: pointer;
     user-select: none;
 
+    isolation: isolate;
+
     @include mixins.typography(label-large);
 
     &::before {

--- a/src/lib/components/list/QItem.scss
+++ b/src/lib/components/list/QItem.scss
@@ -15,6 +15,8 @@
   padding: 0.5rem 1.5rem 0.5rem 1rem;
   gap: 1rem;
 
+  isolation: isolate;
+
   &--clickable {
     cursor: pointer;
   }

--- a/src/lib/components/switch/QSwitch.scss
+++ b/src/lib/components/switch/QSwitch.scss
@@ -46,6 +46,8 @@ $check-map: (
 
     outline: none;
 
+    isolation: isolate;
+
     &--reversed {
       flex-direction: row-reverse;
     }

--- a/src/lib/components/tabs/QTab.scss
+++ b/src/lib/components/tabs/QTab.scss
@@ -17,6 +17,8 @@
   overflow: visible;
   @include mixins.padding("x-md");
 
+  isolation: isolate;
+
   & .q-tab__icon + span {
     margin-left: 0.5rem;
   }


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

## What's new?

> List the changes

- fixes the ripple borders by setting `isolation` in CSS for elements that use it (only some were affected, but this solution is generic)

It seems to only affect some GPU + browser combinations.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
