### PR TITLE
fix: remove svelte warnings about reactivity inside docs files

### DIFF
--- a/plugins/contextPreprocessor.ts
+++ b/plugins/contextPreprocessor.ts
@@ -49,6 +49,43 @@ let context: Record<string, Context> = {};
  * The goal is to automatically handle:
  * * The use of symbols to make sure the context can only be used inside the lib
  * * Reactivity with mutable/readonly variables by defining getters and setters
+ *
+ * It looks for:
+ * * an interface with a name ending in "Context"
+ * * an assigned QContext call.
+ *
+ * If both conditions are met, it searches for the use of
+ * `myContext.set({ ... })` and statically replaces the content inside by getters and setters.
+ *
+ * If the interface uses `readonly` modifiers for some members, the corresponding
+ * setters will not be generated.
+ *
+ * If the conditions are not met, the file will be returned as is and `QContext` will work as a normal Svelte context.
+ *
+ * @example
+ * ```typescript
+ * // Before processing
+ * interface MyContext {
+ *   foo: string;
+ *   readonly bar: string;
+ * }
+ *
+ * export const myContext = QContext<MyContext>("myContext");
+ *
+ * let foo = $state("foo");
+ * let bar = $state("bar");
+ *
+ * myContext.set({ foo, bar });
+ *
+ * // After processing
+ * export const myContext = QContext<MyContext>("myContext");
+ *
+ * myContext.set({
+ *   get foo() { return foo; },
+ *   set foo(value) { foo = value; },
+ *   get bar() { return bar; }
+ * });
+ * ```
  */
 export function preprocessContext(): PreprocessorGroup {
   return {
@@ -103,7 +140,7 @@ function parseContent(content: string, filename: string | undefined): AST.Progra
  * Process all AST nodes
  */
 function processASTNodes(ast: AST.Program) {
-  const contextInterfaces = collectContextInterfaces(ast);
+  const contextInterfaces: AST.TSInterfaceDeclaration[] = [];
 
   ast.body.forEach((node) => {
     handleContextInterfaces(node, contextInterfaces);
@@ -113,19 +150,6 @@ function processASTNodes(ast: AST.Program) {
       handleContextSetting(node, variable);
     }
   });
-}
-
-/**
- * Collect all context interfaces from AST
- */
-function collectContextInterfaces(ast: AST.Program) {
-  const contextInterfaces: AST.TSInterfaceDeclaration[] = [];
-  ast.body.forEach((node) => {
-    if (isContextInterface(node)) {
-      contextInterfaces.push(node);
-    }
-  });
-  return contextInterfaces;
 }
 
 /**
@@ -185,11 +209,7 @@ function handleContextInterfaces(
   node: AST.ProgramStatement,
   contextInterfaces: AST.TSInterfaceDeclaration[]
 ) {
-  if (
-    node.type !== "TSInterfaceDeclaration" ||
-    node.id.type !== "Identifier" ||
-    !node.id.name.endsWith("Context")
-  ) {
+  if (!isContextInterface(node)) {
     return;
   }
 

--- a/src/lib/components/private/QApi.svelte
+++ b/src/lib/components/private/QApi.svelte
@@ -16,10 +16,12 @@
   import { capitalize, escape } from "$utils";
   import type { QComponentDocs, QComponentEvent, QComponentMethod } from "$utils";
   import type { ParsedProp, ParsedSnippet } from "$docgen/props/parseInterface";
+  import { docsCtx } from "./QDocs.svelte";
 
-  // #region:    --- Props
-  let { componentDocs }: { componentDocs: QComponentDocs[] } = $props();
-  // #endregion: --- Props
+  // #region:    --- Context
+  let { componentDocs: docOrDocs } = docsCtx.assertGet("QApi should be used inside QDocs");
+  const componentDocs = Array.isArray(docOrDocs) ? docOrDocs : [docOrDocs];
+  // #endregion: --- Context
 
   // #region:    --- Reactive variables
   let api: (keyof QComponentDocs["docs"])[] = $state(componentDocs.map(() => "props"));

--- a/src/lib/components/private/QDocs.svelte
+++ b/src/lib/components/private/QDocs.svelte
@@ -6,13 +6,17 @@
     display?: Snippet;
     pre?: Snippet;
     usage?: Snippet;
-    snippets?: Record<string, string>;
-    componentDocs?: QComponentDocs | QComponentDocs[];
     docName?: string;
     docDescription?: string;
   }
 
-  export const docsCtx = QContext<{ readonly snippets: Props["snippets"] }>("QDocs");
+  // Do not rename to end with `Context` or it will be incorrectly processed by the context preprocessor.
+  interface DocsCtx {
+    readonly componentDocs: QComponentDocs | QComponentDocs[];
+    readonly snippets: Record<string, string> | (() => Record<string, string>);
+  }
+
+  export const docsCtx = QContext<DocsCtx>("QDocs");
 </script>
 
 <script lang="ts">
@@ -22,9 +26,12 @@
   import type { Snippet } from "svelte";
 
   // #region:    --- Props
-  let { children, display, pre, usage, snippets, componentDocs, docName, docDescription }: Props =
-    $props();
+  let { children, display, pre, usage, docName, docDescription }: Props = $props();
   // #endregion: --- Props
+
+  // #region:    --- Context
+  const { componentDocs } = docsCtx.get() || { componentDocs: undefined };
+  // #endregion: --- Context
 
   // #region:    --- Non-reactive variables
   let principalDocument = Array.isArray(componentDocs) ? componentDocs[0] : componentDocs;
@@ -42,10 +49,6 @@
 
   const brightness = $derived(Quaff.darkMode.isActive ? 0.7 : 1.2);
   // #endregion: --- Derived values
-
-  // #region:    --- Context
-  docsCtx.set({ snippets });
-  // #endregion: --- Context
 </script>
 
 <div
@@ -96,7 +99,7 @@
 
   <div class="q-page">
     {#if componentDocs}
-      <QApi componentDocs={Array.isArray(componentDocs) ? componentDocs : [componentDocs]} />
+      <QApi />
     {/if}
 
     {@render pre?.()}

--- a/src/lib/components/private/QDocsSection.svelte
+++ b/src/lib/components/private/QDocsSection.svelte
@@ -10,18 +10,21 @@
     noCode?: boolean;
   };
 
+  // #region:    --- Context
+  const { snippets } = docsCtx.get() || { snippets: undefined };
+
+  // #endregion: --- Context
+
   // #region:    --- Props
   let { title, noCode = false, sectionDescription, children }: QDocsSectionProps = $props();
   // #endregion: --- Props
 
   // #region:    --- Reactive variables
   let dialog = $state(false);
-
-  const ctx = docsCtx.get();
   // #endregion: --- Reactive variables
 
   // #region:    --- Derived values
-  const code = $derived(ctx?.snippets?.[title]);
+  const code = $derived(typeof snippets === "function" ? snippets()[title] : snippets?.[title]);
 
   // Create a kebab-case id from the title to be able to link to this section
   const id = $derived(title.toLowerCase().replaceAll(" ", "-"));

--- a/src/lib/utils/context.ts
+++ b/src/lib/utils/context.ts
@@ -2,7 +2,7 @@ import { getContext, hasContext, setContext } from "svelte";
 
 /**
  * This function allows to manipulate contexts more easily.
- * It avoids having to pass a Svelte store down the components but rather use runes to keep the context reactive.
+ * Coupled with the class preprocessor, it avoids having to bother with reactivity as it automatically creates getters and setters from a typed interface.
  */
 export function QContext<T>(name: string) {
   const sym = Symbol(name);

--- a/src/routes/components/avatar/+page.svelte
+++ b/src/routes/components/avatar/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { QAvatarDocs } from "$components/avatar/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QAvatar } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QAvatarDocs });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QAvatar")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QAvatarDocs}>
+<QDocs>
   {#snippet display()}
     <QAvatar src="/cocktail.jpg" size="5rem" />
   {/snippet}

--- a/src/routes/components/breadcrumbs/+page.svelte
+++ b/src/routes/components/breadcrumbs/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { QBreadcrumbsDocs } from "$components/breadcrumbs/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBreadcrumbs, QBreadcrumbsEl, QCard } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QBreadcrumbsDocs });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QBreadcrumbs")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QBreadcrumbsDocs}>
+<QDocs>
   {#snippet display()}
     <QCard>
       <QBreadcrumbs>

--- a/src/routes/components/button/+page.svelte
+++ b/src/routes/components/button/+page.svelte
@@ -1,17 +1,20 @@
 <script lang="ts">
   import { QBtnDocs } from "$components/button/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn } from "$lib";
   import { QDocs, QDocsSection } from "$private";
 
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QBtnDocs });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QButton")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QBtnDocs}>
+<QDocs>
   {#snippet display()}
     <QBtn icon="star">Star me on Github</QBtn>
   {/snippet}

--- a/src/routes/components/card/+page.svelte
+++ b/src/routes/components/card/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { QCardActionsDocs, QCardDocs, QCardSectionDocs } from "$components/card/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QCard, QCardActions, QCardSection } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: [QCardDocs, QCardSectionDocs, QCardActionsDocs] });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QCard")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={[QCardDocs, QCardSectionDocs, QCardActionsDocs]}>
+<QDocs>
   {#snippet display()}
     <QCard title="Default Card">
       <QCardSection>This is a card with a default configuration.</QCardSection>

--- a/src/routes/components/checkbox/+page.svelte
+++ b/src/routes/components/checkbox/+page.svelte
@@ -1,11 +1,14 @@
 <script lang="ts">
   import QCard from "$components/card/QCard.svelte";
   import { QCheckboxDocs } from "$components/checkbox/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QCheckbox, QIcon, QItem, QItemSection, QList } from "$lib";
   import { QDocs, QDocsSection } from "$private";
 
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QCheckboxDocs });
 
   let value1 = false;
   let value2 = true;
@@ -16,7 +19,7 @@
   <title>{pageTitle("QCheckbox")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QCheckboxDocs}>
+<QDocs>
   {#snippet display()}
     <QCard>
       <QCheckbox label="I agree to the terms and conditions" bind:value={value1} />

--- a/src/routes/components/chip/+page.svelte
+++ b/src/routes/components/chip/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { QChipDocs } from "$components/chip/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QChip } from "$lib";
   import { QDocs, QDocsSection } from "$private";
 
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QChipDocs });
 
   let selectedValue = false;
 </script>
@@ -13,7 +16,7 @@
   <title>{pageTitle("QChip")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QChipDocs}>
+<QDocs>
   {#snippet display()}
     <QChip elevated icon="img:/cocktail.jpg" label="Cocktail" />
   {/snippet}

--- a/src/routes/components/dialog/+page.svelte
+++ b/src/routes/components/dialog/+page.svelte
@@ -13,8 +13,11 @@
   } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import type { QDialogPositionOptions } from "$components/dialog/props";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QDialogDocs });
 
   let displayDialogOpen = $state(false);
   let basicDialogOpen = $state(false);
@@ -41,7 +44,7 @@
   <title>{pageTitle("QDialog")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QDialogDocs}>
+<QDocs>
   {#snippet display()}
     <QBtn label="Open Dialog" onclick={() => (displayDialogOpen = true)} />
     <QDialog bind:value={displayDialogOpen}>

--- a/src/routes/components/drawer/+page.svelte
+++ b/src/routes/components/drawer/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { QDrawerDocs } from "$components/drawer/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import {
     QBtn,
@@ -15,6 +16,8 @@
   import { QDocs, QDocsSection } from "$private";
 
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QDrawerDocs });
 
   let displayDrawerOpen = $state(false);
   let basicDrawerOpen = $state(false);
@@ -35,7 +38,7 @@
   <title>{pageTitle("QDrawer")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QDrawerDocs}>
+<QDocs>
   {#snippet display()}
     <QBtn label="Open drawer" onclick={() => (displayDrawerOpen = !displayDrawerOpen)} />
 

--- a/src/routes/components/expansion-item/+page.svelte
+++ b/src/routes/components/expansion-item/+page.svelte
@@ -2,8 +2,11 @@
   import { QExpansionItemDocs } from "$components/expansion-item/docs";
   import { QExpansionItem, QList, QItemSection, QIcon, QSwitch, QBtn } from "$components";
   import { QDocs, QDocsSection } from "$components/private";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QExpansionItemDocs });
 
   let customExpandedValue = $state(false);
   let switchValue = $state(true);
@@ -13,7 +16,7 @@
   <title>{pageTitle("QExpansionItem")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QExpansionItemDocs}>
+<QDocs>
   {#snippet display()}
     <QList bordered class="surface" style="max-width: 75%">
       <QExpansionItem label="Click me" icon="waving_hand">

--- a/src/routes/components/footer/+page.svelte
+++ b/src/routes/components/footer/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
   import { QFooterDocs } from "$components/footer/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QFooter, QLayout } from "$lib";
   import { QDocs, QDocsSection } from "$private";
 
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QFooterDocs });
 
   const lorem = `Lorem, ipsum dolor sit amet consectetur adipisicing elit. Dolores tempora itaque nulla tenetur distinctio reiciendis quidem. Enim illum dolorum pariatur consequuntur, est aperiam atque quasi dolor quam ratione dicta nostrum.
             Minus tenetur quam doloremque vel tempore saepe veniam fuga animi nostrum error consequuntur suscipit amet culpa, blanditiis optio quasi. Sit, sint. At facilis fugiat cumque. Velit esse officia aspernatur qui?
@@ -32,7 +35,7 @@
   <title>{pageTitle("QFooter")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QFooterDocs}>
+<QDocs>
   {#snippet display()}
     <QLayout class="surface" style="height: 100%; width: 75%; min-width: unset; min-height: unset">
       {#snippet footer()}

--- a/src/routes/components/header/+page.svelte
+++ b/src/routes/components/header/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QHeader, QToolbarTitle, QBtn, QLayout } from "$lib";
   import { QHeaderDocs } from "$lib/components/header/docs";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QHeaderDocs });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QHeader")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QHeaderDocs}>
+<QDocs>
   {#snippet display()}
     <QLayout class="surface" style="height: 100%; width: 75%; min-width: unset; min-height: unset">
       {#snippet header()}

--- a/src/routes/components/icon/+page.svelte
+++ b/src/routes/components/icon/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
   import { QIconDocs } from "$components/icon/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QCard, QIcon } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QIconDocs });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QIcon")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QIconDocs}>
+<QDocs>
   {#snippet display()}
     <QCard>
       <QIcon name="waving_hand" />

--- a/src/routes/components/input/+page.svelte
+++ b/src/routes/components/input/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import { QInputDocs } from "$components/input/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QIcon, QInput } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QInputDocs });
 
   let defaultValue = $state("Initial Value");
   let outlinedValue = $state("");
@@ -29,7 +32,7 @@
   <title>{pageTitle("QInput")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QInputDocs}>
+<QDocs>
   {#snippet display()}
     <QInput bind:value={defaultValue} label="Standard Input" filled class="q-mt-md" />
   {/snippet}

--- a/src/routes/components/layout/+page.svelte
+++ b/src/routes/components/layout/+page.svelte
@@ -19,6 +19,7 @@
   import { QDocs, QDocsSection } from "$private";
   import type { QLayoutProps } from "$components/layout/props";
   import { pageTitle } from "$helpers/pageTitle";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { snippet } from "./docs.snippets";
 
   let displayLeftDrawerElement = $state<ReturnType<typeof QDrawer>>();
@@ -37,9 +38,11 @@
   let rightRailbar = $state(false);
   let rightDrawer = $state(false);
 
-  const snippets = $derived(
-    snippet(view, [showHeader, showFooter, leftRailbar, leftDrawer, rightRailbar, rightDrawer])
-  );
+  docsCtx.set({
+    snippets: () =>
+      snippet(view, [showHeader, showFooter, leftRailbar, leftDrawer, rightRailbar, rightDrawer]),
+    componentDocs: QLayoutDocs,
+  });
 
   let leftDrawerElement = $state<ReturnType<typeof QDrawer>>();
   let leftDrawerShown = $state(true);
@@ -60,7 +63,7 @@
   <title>{pageTitle("QLayout")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QLayoutDocs}>
+<QDocs>
   {#snippet display()}
     <QLayout view="lhh lpr lfr">
       {#snippet header()}

--- a/src/routes/components/list/+page.svelte
+++ b/src/routes/components/list/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
   import { QItemDocs, QItemSectionDocs, QListDocs } from "$components/list/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QAvatar, QCheckbox, QIcon, QInput, QItem, QItemSection, QList, QSwitch } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: [QListDocs, QItemDocs, QItemSectionDocs] });
 
   let selectedItem = $state(0);
   let checkboxValue = $state(false);
@@ -15,7 +18,7 @@
   <title>{pageTitle("QList")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={[QListDocs, QItemDocs, QItemSectionDocs]}>
+<QDocs>
   {#snippet display()}
     <QList bordered class="surface">
       <QItem clickable>

--- a/src/routes/components/menu/+page.svelte
+++ b/src/routes/components/menu/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { QMenuDocs } from "$components/menu/docs";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import {
     QBtn,
@@ -14,6 +15,8 @@
   } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QMenuDocs });
 
   let isDisplayMenuOpen = $state(false);
   let isBasicMenuOpen = $state(false);
@@ -30,7 +33,7 @@
   <title>{pageTitle("QMenu")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QMenuDocs}>
+<QDocs>
   {#snippet display()}
     <QBtn label="Open menu" onclick={() => (isDisplayMenuOpen = !isDisplayMenuOpen)}>
       <QMenu bind:value={isDisplayMenuOpen}>

--- a/src/routes/components/progress/+page.svelte
+++ b/src/routes/components/progress/+page.svelte
@@ -1,10 +1,13 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QCircularProgressDocs, QLinearProgressDocs } from "$components/progress/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QCard, QCardSection, QCircularProgress, QLinearProgress } from "$lib";
   import { QDocs, QDocsSection } from "$private";
 
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: [QLinearProgressDocs, QCircularProgressDocs] });
 
   let linearValue = 30;
   let circularValue = 25;
@@ -16,8 +19,6 @@
 </svelte:head>
 
 <QDocs
-  {snippets}
-  componentDocs={[QLinearProgressDocs, QCircularProgressDocs]}
   docName="QProgress"
   docDescription="QProgress provides visual feedback about the progress of a task or operation. It can be used to indicate the completion status of a process, such as file uploads, downloads, or any other time-consuming tasks."
 >

--- a/src/routes/components/radio/+page.svelte
+++ b/src/routes/components/radio/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QRadioDocs } from "$components/radio/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QCard, QCardSection, QIcon, QItem, QItemSection, QList, QRadio } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QRadioDocs });
 
   let displayValue = $state("option1");
   let selectedValue = $state("option1");
@@ -18,7 +21,7 @@
   <title>{pageTitle("QRadio")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QRadioDocs}>
+<QDocs>
   {#snippet display()}
     <QCard class="flex column q-gap-sm">
       <QRadio value="option1" bind:selected={displayValue} label="Option 1" />

--- a/src/routes/components/railbar/+page.svelte
+++ b/src/routes/components/railbar/+page.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QRailbarDocs } from "$components/railbar/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import {
@@ -16,6 +17,8 @@
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
 
+  docsCtx.set({ snippets, componentDocs: QRailbarDocs });
+
   let selectedRoute = $state("home");
   let leftDrawerOpen = $state(false);
   let rightDrawerOpen = $state(false);
@@ -25,7 +28,7 @@
   <title>{pageTitle("QRailbar")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QRailbarDocs}>
+<QDocs>
   {#snippet display()}
     <QLayout view="hHh LpR fFf" style="height: 300px;">
       {#snippet railbarLeft()}

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -4,7 +4,10 @@
   import { QBtn, QCard, QCardActions, QCardSection, QIcon, QSelect } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import type { QSelectFilterUpdate, QSelectOption } from "$components/select/props";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QSelectDocs });
 
   let selectDisabled = $state(true);
   let dynamicSelect = $state("");
@@ -78,7 +81,7 @@
   <title>{pageTitle("QSelect")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QSelectDocs}>
+<QDocs>
   {#snippet display()}
     <QSelect label="Favorite animal" {options} bind:value filled />
   {/snippet}

--- a/src/routes/components/separator/+page.svelte
+++ b/src/routes/components/separator/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QSeparatorHorizontalDocs, QSeparatorVerticalDocs } from "$components/separator/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import { QCard, QCardSection, QSeparator } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: [QSeparatorHorizontalDocs, QSeparatorVerticalDocs] });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QSeparator")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={[QSeparatorHorizontalDocs, QSeparatorVerticalDocs]}>
+<QDocs>
   {#snippet display()}
     <QCard class="flex column flex-center surface" style="width: 75%; height: 50%">
       <div>Me</div>

--- a/src/routes/components/switch/+page.svelte
+++ b/src/routes/components/switch/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QSwitchDocs } from "$components/switch/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QCard, QCardSection, QIcon, QItem, QItemSection, QList, QSwitch } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QSwitchDocs });
 
   let toggle = $state(false);
   let wifiEnabled = $state(true);
@@ -16,7 +19,7 @@
   <title>{pageTitle("QSwitch")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QSwitchDocs}>
+<QDocs>
   {#snippet display()}
     <QCard>
       <QSwitch bind:value={toggle} label="Toggle me" icons />

--- a/src/routes/components/table/+page.svelte
+++ b/src/routes/components/table/+page.svelte
@@ -4,7 +4,10 @@
   import { QDocs, QDocsSection } from "$private";
   import type { QTableColumn, QTableRow } from "$components/table/props";
   import { pageTitle } from "$helpers/pageTitle";
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QTableDocs });
 
   const columnsDefCode = `const columns = [
   {
@@ -113,7 +116,7 @@
   <title>{pageTitle("QTable")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QTableDocs}>
+<QDocs>
   {#snippet display()}
     <QCard>
       <QTable {columns} rows={rows.slice(0, 3)} bordered flat />

--- a/src/routes/components/tabs/+page.svelte
+++ b/src/routes/components/tabs/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QTabDocs, QTabsDocs } from "$components/tabs/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import { QCard, QCardSection, QIcon, QItem, QItemSection, QList, QTab, QTabs } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: [QTabsDocs, QTabDocs] });
 
   let activeTab = $state("hello");
   let contentTab = $state("tab1");
@@ -14,7 +17,7 @@
   <title>{pageTitle("QTabs")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={[QTabsDocs, QTabDocs]}>
+<QDocs>
   {#snippet display()}
     <QTabs bind:value={activeTab}>
       <QTab name="hello" icon="home">Home</QTab>

--- a/src/routes/components/toolbar/+page.svelte
+++ b/src/routes/components/toolbar/+page.svelte
@@ -1,16 +1,19 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QToolbarDocs } from "$components/toolbar/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QIcon, QInput, QToolbar, QToolbarTitle } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QToolbarDocs });
 </script>
 
 <svelte:head>
   <title>{pageTitle("QToolbar")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QToolbarDocs}>
+<QDocs>
   {#snippet display()}
     <QToolbar border>
       <QBtn flat icon="menu" />

--- a/src/routes/components/tooltip/+page.svelte
+++ b/src/routes/components/tooltip/+page.svelte
@@ -1,9 +1,12 @@
 <script lang="ts">
+  import { docsCtx } from "$components/private/QDocs.svelte";
   import { QTooltipDocs } from "$components/tooltip/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBtn, QCard, QCardActions, QCardSection, QIcon, QTooltip } from "$lib";
   import { QDocs, QDocsSection } from "$private";
   import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: QTooltipDocs });
 
   let tooltipRef = $state<QTooltip<string>>();
   let showControlledTooltip = $state(false);
@@ -13,7 +16,7 @@
   <title>{pageTitle("QTooltip")}</title>
 </svelte:head>
 
-<QDocs {snippets} componentDocs={QTooltipDocs}>
+<QDocs>
   {#snippet display()}
     <QBtn>
       Hover me


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes
- Use context to pass docs and code snippets down the docs component tree
- Add some comments to make preprocessor understanding easier

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
