### PR TITLE
fix: use "disabled" attr name, not "disable"

### DIFF
--- a/src/lib/components/checkbox/QCheckbox.svelte
+++ b/src/lib/components/checkbox/QCheckbox.svelte
@@ -2,18 +2,18 @@
   import type { QCheckboxProps } from "./props";
 
   // #region:    --- Props
-  let { value = $bindable(), label = "", disable = false, ...props }: QCheckboxProps = $props();
+  let { value = $bindable(), label = "", disabled = false, ...props }: QCheckboxProps = $props();
   // #endregion: --- Props
 
   Q.classes("q-checkbox", {
     bemClasses: {
-      disabled: disable,
+      disabled,
     },
     classes: [props.class],
   });
 </script>
 
-<label {...props} class="q-checkbox" aria-disabled={disable || undefined} data-quaff>
-  <input type="checkbox" bind:checked={value} disabled={disable} />
+<label {...props} class="q-checkbox" aria-disabled={disabled || undefined} data-quaff>
+  <input type="checkbox" bind:checked={value} {disabled} />
   <span>{label}</span>
 </label>

--- a/src/lib/components/checkbox/props.ts
+++ b/src/lib/components/checkbox/props.ts
@@ -14,5 +14,5 @@ export interface QCheckboxProps extends HTMLAttributes<HTMLLabelElement> {
    * Puts the checkbox in a disabled state, making it unclickable.
    * @default false
    */
-  disable?: boolean;
+  disabled?: boolean;
 }

--- a/src/lib/components/input/QInput.svelte
+++ b/src/lib/components/input/QInput.svelte
@@ -16,7 +16,7 @@
   // #region:    --- Props
   let {
     dense = false,
-    disable = false,
+    disabled = false,
     error = false,
     errorMessage = undefined,
     filled = false,
@@ -154,7 +154,7 @@
       label,
       "snippet-append": !!append,
       "snippet-prepend": !!prepend,
-      disable,
+      disabled,
       error,
     },
     classes: [userClass, "q-input"],
@@ -165,7 +165,7 @@
   class="q-field"
   {style}
   style:--snippet-prepend-width="{snippetPrependWidth}px"
-  aria-disabled={disable || undefined}
+  aria-disabled={disabled || undefined}
   data-quaff
 >
   {#if before}
@@ -191,8 +191,8 @@
         onkeydown={onKeydown}
         onfocus={onFocus}
         onblur={onBlur}
-        disabled={disable}
-        tabindex={disable === true ? -1 : (tabindex ?? 0)}
+        {disabled}
+        tabindex={disabled === true ? -1 : (tabindex ?? 0)}
       />
       <span class="q-field__label">{label}</span>
 

--- a/src/lib/components/input/props.ts
+++ b/src/lib/components/input/props.ts
@@ -18,7 +18,7 @@ export interface QInputProps extends NativeProps, QInputNativeAttributes {
    *
    * @default false
    */
-  disable?: boolean;
+  disabled?: boolean;
 
   /**
    * Indicates an error state for the input.

--- a/src/lib/components/radio/QRadio.svelte
+++ b/src/lib/components/radio/QRadio.svelte
@@ -6,20 +6,20 @@
     value = "",
     label = "",
     selected = $bindable(),
-    disable = false,
+    disabled = false,
     ...props
   }: QRadioProps = $props();
   // #endregion: --- Props
 
   Q.classes("q-radio", {
     bemClasses: {
-      disabled: disable,
+      disabled,
     },
     classes: [props.class],
   });
 </script>
 
-<label {...props} class="q-radio" aria-disabled={disable || undefined} data-quaff>
-  <input type="radio" bind:group={selected} {value} disabled={disable} />
+<label {...props} class="q-radio" aria-disabled={disabled || undefined} data-quaff>
+  <input type="radio" bind:group={selected} {value} {disabled} />
   <span>{label}</span>
 </label>

--- a/src/lib/components/radio/props.ts
+++ b/src/lib/components/radio/props.ts
@@ -28,5 +28,5 @@ export interface QRadioProps extends HTMLAttributes<HTMLLabelElement> {
    *
    * @default false
    */
-  disable?: boolean;
+  disabled?: boolean;
 }

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -20,7 +20,7 @@
     options,
     multiple = false,
     dense = false,
-    disable = false,
+    disabled = false,
     error = false,
     errorMessage = undefined,
     filled = false,
@@ -86,7 +86,7 @@
 
   // #region:    --- Effects
   $effect(() => {
-    if (disable) {
+    if (disabled) {
       isMenuOpen = false;
     }
   });
@@ -109,7 +109,7 @@
 
   // #region:    --- Functions
   function handleMousedown() {
-    if (disable) {
+    if (disabled) {
       return;
     }
 
@@ -133,7 +133,7 @@
   }
 
   function handleKeydown(e: QSelectEvent<KeyboardEvent>) {
-    if (disable) {
+    if (disabled) {
       return;
     }
 
@@ -308,7 +308,7 @@
       label,
       "snippet-append": !!append,
       "snippet-prepend": !!prepend,
-      disable,
+      disabled,
       error,
       "bottom-space": hint || (error && errorMessage),
       "use-input": useInput,
@@ -349,8 +349,8 @@
         oninput={handleInput}
         onmousedown={handleMousedown}
         onkeydown={handleKeydown}
-        disabled={disable}
-        tabindex={disable === true ? -1 : 0}
+        {disabled}
+        tabindex={disabled === true ? -1 : 0}
         readonly={!useInput}
       />
 

--- a/src/lib/components/select/index.scss
+++ b/src/lib/components/select/index.scss
@@ -46,7 +46,7 @@
     }
   }
 
-  &.q-field--disable {
+  &.q-field--disabled {
     opacity: 0.5;
     &,
     * {

--- a/src/lib/components/select/props.ts
+++ b/src/lib/components/select/props.ts
@@ -41,7 +41,7 @@ export interface QSelectProps extends NativeProps, HTMLAttributes<HTMLDivElement
    *
    * @default false
    */
-  disable?: boolean;
+  disabled?: boolean;
 
   /**
    * Indicates an error state for the select.

--- a/src/lib/components/table/QTable.svelte
+++ b/src/lib/components/table/QTable.svelte
@@ -168,7 +168,7 @@
       outlined
       options={rowsPerPageOptions}
       bind:value={rowsPerPage}
-      disable={rowsPerPageOptions.length <= 1}
+      disabled={rowsPerPageOptions.length <= 1}
     />
     {numberFrom}-{numberTo}&nbsp;of&nbsp;{numberOf}
     <QBtn

--- a/src/lib/composables/useRouterLink.ts
+++ b/src/lib/composables/useRouterLink.ts
@@ -5,7 +5,7 @@ import type { Page } from "@sveltejs/kit";
 export interface UseRouterLinkProps {
   href?: string;
   to?: string;
-  disable?: boolean;
+  disabled?: boolean;
   activeClass?: string;
   replace?: boolean;
 }
@@ -13,7 +13,7 @@ export interface UseRouterLinkProps {
 export const UseRouterLinkPropsDefaults: UseRouterLinkProps = {
   href: undefined,
   to: undefined,
-  disable: false,
+  disabled: false,
   activeClass: undefined,
   replace: false,
 };
@@ -29,7 +29,7 @@ export function isRouteActive(
 
 export function useRouterLink<T extends UseRouterLinkProps>(props: T) {
   const hasLink = [props.to, props.href].some((entry) => typeof entry !== "undefined");
-  const linkClasses = createClasses([hasLink && "q-link", props.disable && "disable"]);
+  const linkClasses = createClasses([hasLink && "q-link", props.disabled && "disabled"]);
 
   const linkAttributes = {
     href: props.to || props.href,

--- a/src/lib/css/shared/q-field.scss
+++ b/src/lib/css/shared/q-field.scss
@@ -342,7 +342,7 @@
     padding-left: 0.75rem;
   }
 
-  &--disable {
+  &--disabled {
     opacity: 0.5;
     &,
     * {

--- a/src/routes/components/checkbox/+page.svelte
+++ b/src/routes/components/checkbox/+page.svelte
@@ -42,13 +42,13 @@
         {#snippet sectionDescription()}
           Checkboxes can be in different states: unchecked, checked, or disabled. The state is
           controlled by the <code>value</code> prop for checked/unchecked and the
-          <code>disable</code> prop for disabled state.
+          <code>disabled</code> prop for disabled state.
         {/snippet}
 
         <QCheckbox class="q-ma-sm" label="Unchecked by default" bind:value={value3} />
         <QCheckbox class="q-ma-sm" label="Checked by default" bind:value={value2} />
-        <QCheckbox class="q-ma-sm" label="Disabled unchecked" value={false} disable />
-        <QCheckbox class="q-ma-sm" label="Disabled checked" value={true} disable />
+        <QCheckbox class="q-ma-sm" label="Disabled unchecked" value={false} disabled />
+        <QCheckbox class="q-ma-sm" label="Disabled checked" value={true} disabled />
       </QDocsSection>
 
       <QDocsSection title="Two-way Binding">

--- a/src/routes/components/input/+page.svelte
+++ b/src/routes/components/input/+page.svelte
@@ -71,18 +71,24 @@
 
       <QDocsSection title="Disabled State">
         {#snippet sectionDescription()}
-          The <code>disable</code> prop prevents user interaction and visually indicates the input is
+          The <code>disabled</code> prop prevents user interaction and visually indicates the input is
           inactive.
         {/snippet}
-        <QInput bind:value={disabledValue} label="Disabled Standard" class="q-mt-md" disable />
+        <QInput bind:value={disabledValue} label="Disabled Standard" class="q-mt-md" disabled />
         <QInput
           bind:value={disabledValue}
           label="Disabled Outlined"
           class="q-mt-md"
-          disable
+          disabled
           outlined
         />
-        <QInput bind:value={disabledValue} label="Disabled Filled" class="q-mt-md" disable filled />
+        <QInput
+          bind:value={disabledValue}
+          label="Disabled Filled"
+          class="q-mt-md"
+          disabled
+          filled
+        />
       </QDocsSection>
 
       <QDocsSection title="Validation and Hints">

--- a/src/routes/components/radio/+page.svelte
+++ b/src/routes/components/radio/+page.svelte
@@ -75,19 +75,19 @@
 
       <QDocsSection title="Disabled State">
         {#snippet sectionDescription()}
-          Radio buttons can be disabled using the <code>disable</code> prop. Disabled radio buttons cannot
+          Radio buttons can be disabled using the <code>disabled</code> prop. Disabled radio buttons cannot
           be interacted with and display with a muted appearance to indicate they're unavailable.
         {/snippet}
 
         <div class="q-ma-sm">
           <QRadio class="q-ma-sm" value="enabled" label="Enabled radio button" />
-          <QRadio class="q-ma-sm" value="disabled" label="Disabled radio button" disable />
+          <QRadio class="q-ma-sm" value="disabled" label="Disabled radio button" disabled />
           <QRadio
             class="q-ma-sm"
             value="disabled-selected"
             selected="disabled-selected"
             label="Disabled and selected"
-            disable
+            disabled
           />
         </div>
       </QDocsSection>

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -266,7 +266,7 @@
 
       <QDocsSection title="Disabled State">
         {#snippet sectionDescription()}
-          Use the <code>disable</code> prop to prevent user interaction with the select component. Disabled
+          Use the <code>disabled</code> prop to prevent user interaction with the select component. Disabled
           selects maintain their appearance but don't respond to user input.
         {/snippet}
 
@@ -276,7 +276,7 @@
             value={select}
             {options}
             label="Disabled select"
-            disable={selectDisabled}
+            disabled={selectDisabled}
           />
           <div class="">
             <QBtn size="sm" label="Enable" onclick={() => (selectDisabled = false)} />


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## What's new?

> List the changes

We've inconsistently mixed the attribute name `disabled` with `disable` to maintain stronger API compatibility with Quasar. It seems however there is no good reason to use `disable` and we'd like Quaff to follow the more generic standard attribute name `disabled` instead.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
