### PR TITLE
feat: type widening

### DIFF
--- a/src/lib/components/input/QInput.svelte
+++ b/src/lib/components/input/QInput.svelte
@@ -46,8 +46,9 @@
   // #endregion: --- Props
 
   // #region:    --- Derived values
+  const nativeValue = $derived(value ?? "");
   const displayValue = $derived(
-    mask ? maskValue(String(value ?? ""), mask, fillMask) : (value ?? "")
+    mask ? maskValue(String(nativeValue), mask, fillMask) : nativeValue
   );
   const hasValue = $derived(value !== "" && value !== undefined && value !== null);
   const hasNativePlaceholder = $derived(

--- a/src/lib/components/input/props.ts
+++ b/src/lib/components/input/props.ts
@@ -93,7 +93,7 @@ export interface QInputProps extends NativeProps, QInputNativeAttributes {
   /**
    * Current value of the input field. This property is bindable.
    */
-  value: string | number;
+  value: string | number | null;
 
   /**
    * Classes applied to the field wrapper.

--- a/src/lib/components/radio/props.ts
+++ b/src/lib/components/radio/props.ts
@@ -1,12 +1,14 @@
 import type { HTMLAttributes } from "svelte/elements";
 
+export type QRadioValue = string | number | boolean | null;
+
 export interface QRadioProps extends HTMLAttributes<HTMLLabelElement> {
   /**
    * Value associated with this radio button. Used when comparing against the selected value.
    *
    * @default ""
    */
-  value: string;
+  value: QRadioValue;
 
   /**
    * Text label displayed next to the radio button.
@@ -21,7 +23,7 @@ export interface QRadioProps extends HTMLAttributes<HTMLLabelElement> {
    *
    * @default undefined
    */
-  selected?: unknown;
+  selected?: QRadioValue;
 
   /**
    * When true, prevents user interaction with the radio button.

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -11,7 +11,7 @@
     getOptionLabel,
     normalizeOptionIndex,
   } from "./option";
-  import type { QSelectOption, QSelectProps } from "./props";
+  import type { QSelectOption, QSelectProps, QSelectValue } from "./props";
 
   type QSelectEvent<T> = QEvent<T, HTMLDivElement>;
 
@@ -253,9 +253,10 @@
   }
 
   function isSelected(option: QSelectOption) {
+    const isArray = (val: QSelectValue): val is QSelectOption[] => Array.isArray(val);
     return multiple
-      ? Array.isArray(value) && value.some((opt) => doValuesMatch(opt, option))
-      : doValuesMatch(value as QSelectOption, option);
+      ? isArray(value) && value.some((opt) => doValuesMatch(opt, option))
+      : !isArray(value) && doValuesMatch(value, option);
   }
 
   function handleOptionMousedown(evt: MouseEvent) {

--- a/src/lib/components/select/props.ts
+++ b/src/lib/components/select/props.ts
@@ -4,7 +4,7 @@ import type { HTMLAttributes } from "svelte/elements";
 
 export type QSelectOption = string | number | { label: string | number; value: string | number };
 
-export type QSelectValue = QSelectOption | QSelectOption[];
+export type QSelectValue = QSelectOption | QSelectOption[] | null;
 
 export type QSelectFilterUpdate = (callbackFn: () => void | Promise<void>) => void;
 


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- feat(QInput): allow `null` value
- feat(QSelect): allow `null` value
- feat(QRadio): allow `number`, `boolean` and `null` value

These alignments make it possible to use these components a bit more flexible, without having too loose types like `any`.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
