### PR TITLE
refactor: improve tooltip api to avoid unnecessary DOM traversing

### DIFF
--- a/docgen/props/parseInterface.ts
+++ b/docgen/props/parseInterface.ts
@@ -152,17 +152,23 @@ function evaluateTypeNode(node: ts.TypeNode): PropType | (PropType | SnippetType
       return [];
     }
 
-    return node.members.map((member: ts.PropertySignature | ts.IndexSignatureDeclaration) => ({
-      propName: ts.isPropertySignature(member)
+    return node.members.map((member: ts.PropertySignature | ts.IndexSignatureDeclaration) => {
+      const propName = ts.isPropertySignature(member)
         ? member.name.getText()
-        : `[${member.parameters.map((param) => param.getText()).join(", ")}]`,
-      isClickable:
+        : `[${member.parameters.map((param) => param.getText()).join(", ")}]`;
+
+      const isClickable =
         !!member.type &&
-        ts.isTypeReferenceNode(member.type) &&
-        !member.type?.getText().startsWith("Attachment"),
-      optional: !!member.questionToken,
-      name: member.type!.getText().trim(),
-    }));
+        !member.type.getText().startsWith("Attachment") &&
+        ts.isTypeReferenceNode(member.type);
+
+      return {
+        propName,
+        isClickable,
+        optional: !!member.questionToken,
+        name: member.type!.getText().trim(),
+      };
+    });
   }
 
   const name = node.getText().trim();

--- a/docgen/props/parseInterface.ts
+++ b/docgen/props/parseInterface.ts
@@ -144,13 +144,22 @@ function evaluateTypeNode(node: ts.TypeNode): PropType | (PropType | SnippetType
   }
 
   if (ts.isTypeLiteralNode(node)) {
-    if (!node.members.every(ts.isPropertySignature)) {
+    if (
+      !node.members.every(
+        (member) => ts.isPropertySignature(member) || ts.isIndexSignatureDeclaration(member)
+      )
+    ) {
       return [];
     }
 
-    return (node.members as ts.NodeArray<ts.PropertySignature>).map((member) => ({
-      propName: member.name.getText(),
-      isClickable: !!member.type && ts.isTypeReferenceNode(member.type),
+    return node.members.map((member: ts.PropertySignature | ts.IndexSignatureDeclaration) => ({
+      propName: ts.isPropertySignature(member)
+        ? member.name.getText()
+        : `[${member.parameters.map((param) => param.getText()).join(", ")}]`,
+      isClickable:
+        !!member.type &&
+        ts.isTypeReferenceNode(member.type) &&
+        !member.type?.getText().startsWith("Attachment"),
       optional: !!member.questionToken,
       name: member.type!.getText().trim(),
     }));

--- a/src/lib/components/button/QBtn.svelte
+++ b/src/lib/components/button/QBtn.svelte
@@ -1,5 +1,4 @@
 <script lang="ts">
-  import { onMount } from "svelte";
   import { QCircularProgress, QIcon } from "$lib";
   import { useSize } from "$composables";
   import { ripple } from "$helpers";
@@ -80,17 +79,6 @@
     return "primary";
   });
   // #endregion: --- Derived values
-
-  // #region:    --- Lifecycle
-  onMount(() => {
-    const { width, height } = qBtnLabel.getBoundingClientRect();
-
-    // This is required for buttons with no label and with a tooltip to be round
-    if (width === 0 && height === 0) {
-      qBtn.classList.add("q-btn--round");
-    }
-  });
-  // #endregion: --- Lifecycle
 
   // #region:    --- Functions
   function stopIfDisabled(e: QBtnMouseEvent) {

--- a/src/lib/components/tooltip/QTooltip.svelte
+++ b/src/lib/components/tooltip/QTooltip.svelte
@@ -1,6 +1,7 @@
 <script lang="ts" generics="T extends HTMLElement | string">
   import { mount, onMount, unmount, untrack } from "svelte";
   import { on } from "svelte/events";
+  import { type Attachment, createAttachmentKey } from "svelte/attachments";
   import QTooltipBase from "./QTooltipBase.svelte";
   import type { QTooltipProps } from "./props";
 
@@ -10,9 +11,10 @@
     value = $bindable(false),
     position = "bottom",
     offset = { x: 0, y: 0 },
-    delay = 50,
-    hideDelay = 50,
+    delay = 250,
+    hideDelay = 250,
     children,
+    trigger,
     ...props
   }: QTooltipProps<T> = $props();
   // #endregion: --- Props
@@ -30,7 +32,6 @@
   // #endregion: --- Non-reactive variables
 
   // #region:    --- Reactive variables
-  let tooltipHelperEl = $state<HTMLDivElement>();
   let tooltipEl = $state<HTMLDivElement>();
 
   let realTarget = $state<HTMLElement>();
@@ -47,50 +48,19 @@
 
   // #region:    --- Lifecycle
   onMount(() => {
-    if (target) {
-      realTarget =
-        typeof target === "string"
-          ? document.querySelector<HTMLElement>(target) || undefined
-          : target;
-    } else {
-      let parent = tooltipHelperEl?.parentElement || null;
+    if (!target) {
+      return;
+    }
+    realTarget =
+      typeof target === "string"
+        ? document.querySelector<HTMLElement>(target) || undefined
+        : target;
 
-      while (parent) {
-        if (parent.attributes.getNamedItem("data-quaff")) {
-          realTarget = parent;
-          break;
-        } else {
-          parent = parent.parentElement;
-        }
-      }
+    if (!realTarget) {
+      return;
     }
 
-    if (realTarget) {
-      removeTargetMouseEnterListener = on(realTarget, "mouseenter", show);
-      removeTargetMouseLeaveListener = on(realTarget, "mouseleave", hide);
-    }
-
-    return () => {
-      removeTargetMouseEnterListener?.();
-      removeTargetMouseLeaveListener?.();
-
-      removeTooltipMouseEnterListener?.();
-      removeTooltipMouseLeaveListener?.();
-
-      removeWindowWheelListener?.();
-
-      if (mountedTooltip) {
-        unmount(mountedTooltip);
-      }
-
-      if (timerShow) {
-        clearTimeout(timerShow);
-      }
-
-      if (timerHide) {
-        clearTimeout(timerHide);
-      }
-    };
+    return attachTooltip(realTarget);
   });
   // #endregion: --- Lifecycle
 
@@ -174,6 +144,34 @@
   // #endregion: --- Methods
 
   // #region:    --- Functions
+  const attachTooltip: Attachment<HTMLElement> = (element) => {
+    realTarget = element;
+    removeTargetMouseEnterListener = on(element, "mouseenter", show);
+    removeTargetMouseLeaveListener = on(element, "mouseleave", hide);
+
+    return () => {
+      removeTargetMouseEnterListener?.();
+      removeTargetMouseLeaveListener?.();
+
+      removeTooltipMouseEnterListener?.();
+      removeTooltipMouseLeaveListener?.();
+
+      removeWindowWheelListener?.();
+
+      if (mountedTooltip) {
+        unmount(mountedTooltip);
+      }
+
+      if (timerShow) {
+        clearTimeout(timerShow);
+      }
+
+      if (timerHide) {
+        clearTimeout(timerHide);
+      }
+    };
+  };
+
   function abortHide() {
     if (timerHide) {
       clearTimeout(timerHide);
@@ -202,6 +200,6 @@
   // #endregion: --- Functions
 </script>
 
-{#if !target}
-  <div bind:this={tooltipHelperEl} class="q-tooltip__helper"></div>
+{#if !target && trigger}
+  {@render trigger({ [createAttachmentKey()]: attachTooltip })}
 {/if}

--- a/src/lib/components/tooltip/docs.ts
+++ b/src/lib/components/tooltip/docs.ts
@@ -1,6 +1,5 @@
-import { QToolbarDocsSnippets } from "$components/header/docs.props";
 import type { QComponentDocs } from "$utils";
-import { QTooltipDocsProps } from "./docs.props";
+import { QTooltipDocsProps, QTooltipDocsSnippets } from "./docs.props";
 
 export const QTooltipDocs: QComponentDocs = {
   name: "QTooltip",
@@ -8,7 +7,7 @@ export const QTooltipDocs: QComponentDocs = {
     "The Tooltip component displays informative text on hover or focus, providing additional context.",
   docs: {
     props: QTooltipDocsProps,
-    snippets: QToolbarDocsSnippets,
+    snippets: QTooltipDocsSnippets,
     methods: [],
     events: [],
   },

--- a/src/lib/components/tooltip/props.ts
+++ b/src/lib/components/tooltip/props.ts
@@ -1,3 +1,5 @@
+import { Snippet } from "svelte";
+import { Attachment } from "svelte/attachments";
 import type { HTMLAttributes } from "svelte/elements";
 
 export type QTooltipPosition =
@@ -39,13 +41,20 @@ export interface QTooltipProps<T extends Element | string> extends HTMLAttribute
 
   /**
    * Delay in milliseconds before the tooltip appears.
-   * @default 0
+   * @default 250
    */
   delay?: number;
 
   /**
    * Delay in milliseconds before the tooltip is hidden.
-   * @default 0
+   * @default 250
    */
   hideDelay?: number;
+
+  /**
+   * Snippet holding the trigger element/component. Its scope contains a Svelte attachment that should be spread on the trigger element.
+   *
+   * @default undefined
+   */
+  trigger?: Snippet<[{ [k: symbol]: Attachment<HTMLElement> }]>;
 }

--- a/src/routes/components/tooltip/+page.svelte
+++ b/src/routes/components/tooltip/+page.svelte
@@ -18,10 +18,13 @@
 
 <QDocs>
   {#snippet display()}
-    <QBtn>
-      Hover me
-      <QTooltip>Simple tooltip</QTooltip>
-    </QBtn>
+    <QTooltip>
+      {#snippet trigger(props)}
+        <QBtn {...props}>Hover me</QBtn>
+      {/snippet}
+
+      Simple tooltip
+    </QTooltip>
   {/snippet}
 
   {#snippet usage()}
@@ -33,14 +36,21 @@
         {/snippet}
 
         <div class="flex q-gap-md q-ma-sm">
-          <QBtn>
-            Hover me
-            <QTooltip>Simple tooltip</QTooltip>
-          </QBtn>
+          <QTooltip>
+            {#snippet trigger(props)}
+              <QBtn {...props}>Hover me</QBtn>
+            {/snippet}
 
-          <QBtn icon="help">
-            <QTooltip>Help information</QTooltip>
-          </QBtn>
+            Simple tooltip
+          </QTooltip>
+
+          <QTooltip>
+            {#snippet trigger(props)}
+              <QBtn icon="help" {...props} />
+            {/snippet}
+
+            Help information
+          </QTooltip>
         </div>
       </QDocsSection>
 
@@ -51,48 +61,77 @@
         {/snippet}
 
         <div class="row q-gutter-md q-ma-sm" style="max-width: 600px;">
-          <QBtn class="col-4">
-            Top Left
-            <QTooltip position="top-left">top-left</QTooltip>
-          </QBtn>
+          <QTooltip position="top-left">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Top Left</QBtn>
+            {/snippet}
 
-          <QBtn class="col-4">
-            Top
-            <QTooltip position="top">top</QTooltip>
-          </QBtn>
+            top-left
+          </QTooltip>
 
-          <QBtn class="col-4">
-            Top Right
-            <QTooltip position="top-right">top-right</QTooltip>
-          </QBtn>
-          <QBtn class="col-4">
-            Left
-            <QTooltip position="left">left</QTooltip>
-          </QBtn>
+          <QTooltip position="top">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Top</QBtn>
+            {/snippet}
 
-          <QBtn class="col-4">
-            Default
-            <QTooltip>default (bottom)</QTooltip>
-          </QBtn>
+            top
+          </QTooltip>
 
-          <QBtn class="col-4">
-            Right
-            <QTooltip position="right">right</QTooltip>
-          </QBtn>
-          <QBtn class="col-4">
-            Bottom Left
-            <QTooltip position="bottom-left">bottom-left</QTooltip>
-          </QBtn>
+          <QTooltip position="top-right">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Top Right</QBtn>
+            {/snippet}
 
-          <QBtn class="col-4">
-            Bottom
-            <QTooltip position="bottom">bottom</QTooltip>
-          </QBtn>
+            top-right
+          </QTooltip>
 
-          <QBtn class="col-4">
-            Bottom Right
-            <QTooltip position="bottom-right">bottom-right</QTooltip>
-          </QBtn>
+          <QTooltip position="left">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Left</QBtn>
+            {/snippet}
+
+            left
+          </QTooltip>
+
+          <QTooltip>
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Default</QBtn>
+            {/snippet}
+
+            default (bottom)
+          </QTooltip>
+
+          <QTooltip position="right">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Right</QBtn>
+            {/snippet}
+
+            right
+          </QTooltip>
+
+          <QTooltip position="bottom-left">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Bottom Left</QBtn>
+            {/snippet}
+
+            bottom-left
+          </QTooltip>
+
+          <QTooltip position="bottom">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Bottom</QBtn>
+            {/snippet}
+
+            bottom
+          </QTooltip>
+
+          <QTooltip position="bottom-right">
+            {#snippet trigger(props)}
+              <QBtn class="col-4" {...props}>Bottom Right</QBtn>
+            {/snippet}
+
+            bottom-right
+          </QTooltip>
         </div>
       </QDocsSection>
 
@@ -104,17 +143,21 @@
         {/snippet}
 
         <div class="flex q-gap-md q-ma-sm">
-          <QBtn>
-            No offset
-            <QTooltip>Default position</QTooltip>
-          </QBtn>
+          <QTooltip>
+            {#snippet trigger(props)}
+              <QBtn {...props}>No offset</QBtn>
+            {/snippet}
 
-          <QBtn>
-            With offset
-            <QTooltip offset={{ x: 50, y: 10 }}>
-              Offset by 50px horizontally and 10px vertically
-            </QTooltip>
-          </QBtn>
+            Default position
+          </QTooltip>
+
+          <QTooltip offset={{ x: 50, y: 10 }}>
+            {#snippet trigger(props)}
+              <QBtn {...props}>With offset</QBtn>
+            {/snippet}
+
+            Offset by 50px horizontally and 10px vertically
+          </QTooltip>
         </div>
       </QDocsSection>
 
@@ -125,17 +168,21 @@
         {/snippet}
 
         <div class="flex q-gap-md q-ma-sm">
-          <QBtn>
-            Quick tooltip
-            <QTooltip delay={0} hideDelay={0}>Appears and disappears immediately</QTooltip>
-          </QBtn>
+          <QTooltip delay={0} hideDelay={0}>
+            {#snippet trigger(props)}
+              <QBtn {...props}>Quick tooltip</QBtn>
+            {/snippet}
 
-          <QBtn>
-            Delayed tooltip
-            <QTooltip delay={500} hideDelay={1000}
-              >Takes 0.5s to appear and 1s to disappear</QTooltip
-            >
-          </QBtn>
+            Appears and disappears immediately
+          </QTooltip>
+
+          <QTooltip delay={500} hideDelay={1000}>
+            {#snippet trigger(props)}
+              <QBtn {...props}>Delayed tooltip</QBtn>
+            {/snippet}
+
+            Takes 0.5s to appear and 1s to disappear
+          </QTooltip>
         </div>
       </QDocsSection>
 
@@ -163,28 +210,31 @@
         {/snippet}
 
         <div class="flex q-gap-md q-ma-sm">
-          <QBtn icon="info">
-            <QTooltip class="error">
-              <div class="flex items-center">
-                <QIcon name="warning" class="q-mr-sm" />
-                <span>Important information</span>
-              </div>
-            </QTooltip>
-          </QBtn>
+          <QTooltip class="error">
+            {#snippet trigger(props)}
+              <QBtn icon="info" {...props} />
+            {/snippet}
 
-          <QBtn>
-            Rich tooltip
-            <QTooltip>
-              <QCard>
-                <QCardSection>
-                  <h6 class="q-mt-none q-mb-sm">Tooltip Title</h6>
-                  <p class="q-mb-none">
-                    This tooltip contains formatted content with multiple elements.
-                  </p>
-                </QCardSection>
-              </QCard>
-            </QTooltip>
-          </QBtn>
+            <div class="flex items-center">
+              <QIcon name="warning" class="q-mr-sm" />
+              <span>Important information</span>
+            </div>
+          </QTooltip>
+
+          <QTooltip>
+            {#snippet trigger(props)}
+              <QBtn {...props}>Rich tooltip</QBtn>
+            {/snippet}
+
+            <QCard>
+              <QCardSection>
+                <h6 class="q-mt-none q-mb-sm">Tooltip Title</h6>
+                <p class="q-mb-none">
+                  This tooltip contains formatted content with multiple elements.
+                </p>
+              </QCardSection>
+            </QCard>
+          </QTooltip>
         </div>
       </QDocsSection>
 
@@ -196,12 +246,14 @@
 
         <div class="flex flex-col q-gap-md q-ma-sm">
           <div class="flex items-center q-gap-md">
-            <QBtn>
-              My button
-              <QTooltip bind:value={showControlledTooltip}>
-                This tooltip is controlled programmatically
-              </QTooltip>
-            </QBtn>
+            <QTooltip bind:value={showControlledTooltip}>
+              {#snippet trigger(props)}
+                <QBtn {...props}>My button</QBtn>
+              {/snippet}
+
+              This tooltip is controlled programmatically
+            </QTooltip>
+
             <QBtn onclick={() => (showControlledTooltip = !showControlledTooltip)}>
               Toggle tooltip
             </QBtn>
@@ -243,39 +295,49 @@
         {/snippet}
 
         <div class="flex q-gap-md q-ma-sm">
-          <QBtn>
-            Default style
-            <QTooltip>Default tooltip style</QTooltip>
-          </QBtn>
+          <QTooltip>
+            {#snippet trigger(props)}
+              <QBtn {...props}>Default style</QBtn>
+            {/snippet}
 
-          <QBtn>
-            Custom style
-            <QTooltip class="primary">Custom colored tooltip</QTooltip>
-          </QBtn>
+            Default tooltip style
+          </QTooltip>
 
-          <QBtn>
-            Larger tooltip
-            <QTooltip class="q-pa-md">Tooltip with more padding</QTooltip>
-          </QBtn>
+          <QTooltip class="primary">
+            {#snippet trigger(props)}
+              <QBtn {...props}>Custom style</QBtn>
+            {/snippet}
 
-          <QBtn>
-            Rich tooltip
-            <QTooltip position="top">
-              <QCard>
-                <QCardSection>
-                  <h6 class="q-mt-none q-mb-sm">Tooltip Title</h6>
-                  <div>This tooltip contains formatted content with multiple elements.</div>
-                  <div>
-                    It is typically use with <code>QCard</code> to display rich content.
-                  </div>
-                </QCardSection>
-                <QCardActions align="right">
-                  <QBtn flat label="Action 1" />
-                  <QBtn flat label="Action 2" />
-                </QCardActions>
-              </QCard>
-            </QTooltip>
-          </QBtn>
+            Custom colored tooltip
+          </QTooltip>
+
+          <QTooltip class="q-pa-md">
+            {#snippet trigger(props)}
+              <QBtn {...props}>Larger tooltip</QBtn>
+            {/snippet}
+
+            Tooltip with more padding
+          </QTooltip>
+
+          <QTooltip>
+            {#snippet trigger(props)}
+              <QBtn {...props}>Rich tooltip</QBtn>
+            {/snippet}
+
+            <QCard>
+              <QCardSection>
+                <h6 class="q-mt-none q-mb-sm">Tooltip Title</h6>
+                <div>This tooltip contains formatted content with multiple elements.</div>
+                <div>
+                  It is typically use with <code>QCard</code> to display rich content.
+                </div>
+              </QCardSection>
+              <QCardActions align="right">
+                <QBtn flat label="Action 1" />
+                <QBtn flat label="Action 2" />
+              </QCardActions>
+            </QCard>
+          </QTooltip>
         </div>
       </QDocsSection>
     </div>


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## What's new?

> List the changes

- Use snippet to define `QTooltip`'s trigger element (more flexible, more performant, less elements in DOM and avoid unnecessary code in other components)
- Remove unnecessary code in `QBtn` checking for tooltip (for icon buttons)
- Refactor the doc type parser to allow `[k: Type]: Type` notation parsing inside snippet types
- Update docs with the new API

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
