### PR TITLE
fix: remove QTab isolation to fix indicator animation

### DIFF
--- a/src/lib/components/tabs/QTab.scss
+++ b/src/lib/components/tabs/QTab.scss
@@ -17,8 +17,6 @@
   overflow: visible;
   @include mixins.padding("x-md");
 
-  isolation: isolate;
-
   & .q-tab__icon + span {
     margin-left: 0.5rem;
   }


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Remove `isolation: isolate;` which broke the indicator animation

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

Closes #209 
