### PR TITLE
refactor: improve interface parser to fix bugs and handle more cases

### DIFF
--- a/docgen/props/parsePropsInterface/defs.ts
+++ b/docgen/props/parsePropsInterface/defs.ts
@@ -1,27 +1,62 @@
-export type MaybeParsed = ParsedType | string;
-
-/** Represents a resolved type with an optional source URL for external types. */
-export interface ParsedType {
-  /** Text representation of a single type (e.g. `"boolean"`, `"MaterialSymbol"`, `"\`img:${string}\`"`). */
-  text: string;
-  /** The computed types for all internal type references contained in this type */
-  computedTypes?: Record<string, MaybeParsed | MaybeParsed[]>;
-  /** URL pointing to external documentation for this type (e.g. Material Icons page). Only present for types listed in `TypeSrcMap`. */
-  typeSrc?: string;
+/**
+ * Corresponds to a type definition from an external package (including built-in DOM types).
+ * Those types link to external documentation sources like MDN, google fonts or svelte's docs.
+ *
+ * For example, `MaterialSymbol` will link to `fonts.google.com/icons`.
+ */
+export interface ExternalType {
   /**
-   * A string of TypeScript definitions of the complex types in this type, formatted with prettier.
-   *
-   * This allows the frontend to show hover popups of types in components' props.
+   * The name of the type as it appears in the source code (e.g. `MaterialSymbol`)
    */
-  typeDefinition?: string;
+  name: string;
+  /**
+   * The URL to the external documentation source
+   */
+  typeSrc: string;
 }
+
+/**
+ * Type used for primitive types or types that couldn't be resolved to an external type.
+ *
+ * For example, `string`, `number`, `boolean`, etc.
+ */
+export interface StandardType {
+  /**
+   * The full text of the type definition
+   */
+  definition: string;
+}
+
+/**
+ * Type used for complex types, such as `interface`s or `type` aliases.
+ *
+ * These types can (but are not bound to) depend on other "complex" types.
+ * In this case, the name of those other types will be accessible through the `dependencies` property.
+ *
+ * For example, `QSize` or `CssValue`.
+ */
+export interface ComplexType extends StandardType {
+  /**
+   * The name of the type as it appears in the source code (e.g. `QSize`)
+   */
+  name: string;
+  /**
+   * The names of other "complex" types that this type depends on (e.g. `["CssUnit"]` which `CssValue` depends on)
+   */
+  dependencies: string[];
+}
+
+/**
+ * A parsed type. Can be external, standard or complex.
+ */
+export type ParsedType = ExternalType | StandardType | ComplexType;
 
 /** Represents a generic type parameter of an interface (e.g. `<T extends string>`). */
 export interface ParsedGeneric {
   /** Name of the generic type parameter (e.g. `"T"`). */
   name: string;
   /** Constraint text if the generic extends a type (e.g. `"string"`). */
-  constraint?: MaybeParsed;
+  constraint?: ParsedType;
 }
 
 /** Represents a single parsed property from an interface. */
@@ -39,7 +74,7 @@ export interface ParsedProperty {
    */
   flags: number;
   /** The computed type(s) for this property. A single `ParsedType` for simple types, or an array of `ParsedType` for union types. */
-  type: MaybeParsed | MaybeParsed[];
+  type: ParsedType | ParsedType[];
   /** The default value from the `@default` JSDoc tag, if present. */
   default?: string;
 }
@@ -47,11 +82,13 @@ export interface ParsedProperty {
 /** Represents a fully parsed TypeScript interface. */
 export interface ParsedInterface {
   /** The full text of the DOM attributes extension clause, if the interface extends `HTMLAttributes<...>` or similar. */
-  domAttributesConstraint?: string | ParsedType;
+  domAttributesConstraint?: ParsedType;
   /** The interface's generic type parameters. */
   generics: ParsedGeneric[];
   /** All parsed properties, including those inherited from extended internal interfaces. */
   properties: ParsedProperty[];
+  /** The resolved type dependencies for the interface. */
+  typeDependencies: Record<string, ParsedType | ParsedType[]>;
 }
 
 /** Type names whose resolved union values should never be inlined. */
@@ -108,13 +145,22 @@ export const TypeSrcMap = [
   ["BundledLanguage", "https://shiki.style/languages#bundled-languages"],
   ["SpecialLanguage", "https://shiki.style/languages#special-languages"],
   ["BundledTheme", "https://shiki.style/themes#bundled-themes"],
+  ["Snippet", "https://svelte.dev/docs/svelte/snippet#Typing-snippets"],
   [
     "HTMLElementTagNameMap",
     "https://typhonjs-typedoc.github.io/ts-lib-docs/2024/dom/interfaces/HTMLElementTagNameMap.html",
   ],
   [
+    /^(?<event>[A-Z][a-z]+Event)Handler<.*>$/,
+    (event: string) => "https://developer.mozilla.org/en-US/docs/Web/API/" + event,
+  ],
+  [
     /HTMLAttributes<HTMLElement>(?![[])/,
     "https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Global_attributes#list_of_global_attributes",
+  ],
+  [
+    /^(?<element>HTML(?:.+)?Element)$/,
+    (element: string) => `https://developer.mozilla.org/en-us/docs/Web/API/${element}`,
   ],
   [
     /HTML(?<element>.+)Attributes\\["(?<prop>\\w+)"\\]/,
@@ -132,7 +178,12 @@ export const TypeSrcMap = [
       `https://developer.mozilla.org/en-us/docs/Web/API/HTML${element}Element/${prop}`,
   ],
   [
-    /^HTML(?<element>.+)Attributes$|HTMLAttributes<HTML(?<element>.+)Element>/,
+    /HTML(?<element>.+)Attributes/,
+    (element: string) =>
+      `https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/${element.toLowerCase()}#attributes`,
+  ],
+  [
+    /HTMLAttributes<HTML(?<element>.+)Element>/,
     (element: string) =>
       `https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/${element.toLowerCase()}#attributes`,
   ],

--- a/docgen/props/parsePropsInterface/extractor.ts
+++ b/docgen/props/parsePropsInterface/extractor.ts
@@ -1,7 +1,6 @@
 import { Node, TypeFormatFlags } from "ts-morph";
-import { MaybeParsed, type ParsedGeneric, type ParsedType, TypeSrcMap } from "./defs";
+import { type ParsedGeneric, type ParsedType, TypeSrcMap } from "./defs";
 import { parseType } from "./parser";
-import { getText, sortComputedTypes } from "./utils";
 import type { Project, InterfaceDeclaration, Type } from "ts-morph";
 
 /**
@@ -17,7 +16,10 @@ export function extractInterfaces(project: Project, filePath: string) {
 }
 
 /** Parses generic type parameters from an interface declaration into `ParsedGeneric[]`. */
-export async function extractGenerics(interfaceDecl: InterfaceDeclaration) {
+export async function extractGenerics(
+  interfaceDecl: InterfaceDeclaration,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>
+) {
   return Promise.all(
     interfaceDecl.getTypeParameters().map(async (param) => {
       const result: ParsedGeneric = { name: param.getName() };
@@ -25,7 +27,8 @@ export async function extractGenerics(interfaceDecl: InterfaceDeclaration) {
 
       if (constraint) {
         const constraintText = constraint.getText();
-        result.constraint = await parseType(constraintText);
+        const parsed = await parseType(constraintText, typeDependencies, constraint);
+        result.constraint = Array.isArray(parsed) ? parsed[0] : parsed;
       }
 
       return result;
@@ -43,14 +46,14 @@ export function extractTypeSrc(typeText: string) {
         continue;
       }
 
-      const { element, prop } = match.groups || {};
+      const { element, prop, event } = match.groups || {};
 
-      if (!element && !prop) {
-        throw new Error(`Missing element or prop match for ${typeName} in ${typeText}`);
+      if (!element && !prop && !event) {
+        throw new Error(`Missing element, prop or event match for ${typeName} in ${typeText}`);
       }
 
-      if (prop && !element) {
-        return url(prop);
+      if ((prop || event) && !element) {
+        return url(prop ?? event);
       }
 
       return url(element, prop);
@@ -71,14 +74,18 @@ export function extractTypeSrc(typeText: string) {
  * Finds the `HTMLAttributes<...>` or similar DOM extends clause from an interface.
  * Returns the full text (e.g. `HTMLAttributes<HTMLButtonElement>`) or `undefined`.
  */
-export function extractDomConstraint(interfaceDecl: InterfaceDeclaration) {
+export async function extractDomConstraint(
+  interfaceDecl: InterfaceDeclaration,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>
+) {
   const extendsClauses = interfaceDecl.getExtends();
 
   for (const clause of extendsClauses) {
     const text = clause.getText();
     // Match patterns like HTMLAttributes<...>, HTMLDetailsAttributes, etc.
     if (text.includes("HTML") && text.includes("Attributes")) {
-      return parseType(text);
+      const parsed = await parseType(text, typeDependencies, clause);
+      return Array.isArray(parsed) ? parsed[0] : parsed;
     }
   }
 }
@@ -242,74 +249,4 @@ export function extractInternalTypeReferenceSymbol(typeName: string, contextNode
  */
 export function extractTypeText(type: Type, contextNode: Node) {
   return type.getText(contextNode, TypeFormatFlags.NoTruncation | TypeFormatFlags.InTypeAlias);
-}
-
-/**
- * Stringifies the MaybeParsed type to a TypeScript type definition (or a set of defintions).
- */
-export function extractTypeDefinition(maybeParsed: ParsedType, referenceType: string) {
-  if (
-    maybeParsed.text !== referenceType ||
-    !maybeParsed.computedTypes ||
-    !Object.keys(maybeParsed.computedTypes).includes(referenceType)
-  ) {
-    // We ignore types that:
-    // - are not the referenceType
-    // - have no computed types (can happen when `srcType` is set instead)
-    // - don't reference the referenceType
-    return;
-  }
-
-  const sortedEntries = sortComputedTypes(maybeParsed.computedTypes, referenceType);
-
-  if (!sortedEntries.length) {
-    return;
-  }
-
-  const toTypeDef = (
-    typeName: string,
-    computed: MaybeParsed | MaybeParsed[],
-    isNamespaced = false
-  ) => {
-    let toUse;
-
-    if (Array.isArray(computed)) {
-      // It's a union of types that don't reference anything (e.g. primitives)
-      toUse = computed.map(getText).join(" | ");
-    } else {
-      toUse = getText(computed);
-    }
-
-    return isNamespaced
-      ? `\texport type ${typeName.slice(2)} = ${toUse};`
-      : toUse.startsWith("export")
-        ? toUse.slice(7) // remove the `export ` prefix
-        : `type ${typeName} = ${toUse};`;
-  };
-
-  const namespacedQ = [];
-  const global = [];
-
-  for (const index in sortedEntries) {
-    const [typeName, computed] = sortedEntries[index];
-
-    if (typeName.startsWith("Q.")) {
-      namespacedQ.push(toTypeDef(typeName, computed, true));
-
-      continue;
-    }
-
-    if (+index === sortedEntries.length - 1) {
-      global.push("");
-    }
-
-    global.push(toTypeDef(typeName, computed));
-  }
-
-  if (namespacedQ.length) {
-    namespacedQ.unshift("declare namespace Q {");
-    namespacedQ.push("}");
-  }
-
-  return [...namespacedQ, ...global].join("\n");
 }

--- a/docgen/props/parsePropsInterface/parser.ts
+++ b/docgen/props/parsePropsInterface/parser.ts
@@ -1,11 +1,12 @@
-import { InterfaceDeclaration, type Node, type Symbol as MorphSymbol } from "ts-morph";
+import { InterfaceDeclaration, Node, type Symbol as MorphSymbol } from "ts-morph";
 import { format } from "prettier";
 import {
-  MaybeParsed,
+  BUILTIN_TYPES,
   ParsedInterface,
   ParsedProperty,
   ParsedPropertyFlags,
   ParsedType,
+  PRESERVE_TYPE_NAMES,
 } from "./defs";
 import {
   extractDefaultValue,
@@ -13,11 +14,17 @@ import {
   extractDomConstraint,
   extractExtendedInternalProperties,
   extractGenerics,
-  extractTypeDefinition,
+  extractInternalTypeReferenceSymbol,
   extractTypeSrc,
 } from "./extractor";
-import { isPropertyBindable, isPropertyOptional } from "./checker";
+import {
+  isImportedFromExternal,
+  isPropertyBindable,
+  isPropertyOptional,
+  isTypeAlias,
+} from "./checker";
 import { resolvePropertyType } from "./resolver";
+import { removeChildrenComments, splitUnionParts } from "./utils";
 
 /**
  * Parses a full interface declaration into a `ParsedInterface`.
@@ -27,8 +34,10 @@ export async function parseInterface(
   interfaceDecl: InterfaceDeclaration
 ): Promise<[string, ParsedInterface]> {
   const name = interfaceDecl.getName();
-  const generics = await extractGenerics(interfaceDecl);
-  const domAttributesConstraint = await extractDomConstraint(interfaceDecl);
+  const typeDependencies: Record<string, ParsedType | ParsedType[]> = {};
+
+  const generics = await extractGenerics(interfaceDecl, typeDependencies);
+  const domAttributesConstraint = await extractDomConstraint(interfaceDecl, typeDependencies);
 
   const genericNames = new Set(generics.map((generic) => generic.name));
 
@@ -39,7 +48,7 @@ export async function parseInterface(
   // 1. Collect properties from extended internal interfaces
   const extendedProps = extractExtendedInternalProperties(interfaceDecl);
   for (const prop of extendedProps) {
-    const parsed = await parseProperty(prop, interfaceDecl, genericNames);
+    const parsed = await parseProperty(prop, interfaceDecl, genericNames, typeDependencies);
     propertyMap.set(parsed.name, parsed);
   }
 
@@ -49,7 +58,7 @@ export async function parseInterface(
     const proSymbol = prop.getSymbol();
 
     if (proSymbol) {
-      const parsed = await parseProperty(proSymbol, interfaceDecl, genericNames);
+      const parsed = await parseProperty(proSymbol, interfaceDecl, genericNames, typeDependencies);
       propertyMap.set(parsed.name, parsed);
     }
   }
@@ -61,6 +70,7 @@ export async function parseInterface(
   const result: ParsedInterface = {
     generics,
     properties,
+    typeDependencies,
   };
 
   if (domAttributesConstraint) {
@@ -73,38 +83,160 @@ export async function parseInterface(
 /** Parses a given type, creating a `ParsedType` object from a string. */
 export async function parseType(
   typeText: string,
-  computedTypes: Record<string, MaybeParsed | MaybeParsed[]> = {}
-): Promise<MaybeParsed> {
+  typeDependencies: Record<string, ParsedType | ParsedType[]>,
+  contextNode: Node,
+  visited: Set<string> = new Set(),
+  resolvedSymbol?: MorphSymbol
+): Promise<ParsedType | ParsedType[]> {
+  const parts = splitUnionParts(typeText);
+
+  if (parts.length > 1) {
+    const resolvedParts = await Promise.all(
+      parts.map((part) => parseType(part, typeDependencies, contextNode, visited))
+    );
+    return resolvedParts.flat();
+  }
+
   const typeSrc = extractTypeSrc(typeText);
 
-  const result: ParsedType = { text: typeText, typeDefinition: typeText };
-
-  const maybeComputedTypes = Object.keys(computedTypes).length ? computedTypes : undefined;
-
-  if (!typeSrc && !maybeComputedTypes) {
-    return typeText;
-  }
-
   if (typeSrc) {
-    result.typeSrc = typeSrc;
+    const name = typeText;
+    const parsed: ParsedType = { name, typeSrc };
+    typeDependencies[name] = parsed;
+    return parsed;
   }
 
-  if (maybeComputedTypes) {
-    result.computedTypes = maybeComputedTypes;
+  if (PRESERVE_TYPE_NAMES.has(typeText) || BUILTIN_TYPES.has(typeText)) {
+    return { definition: typeText };
   }
 
-  const extractedDefinition = extractTypeDefinition(result, typeText);
-
-  if (extractedDefinition) {
-    const formatted = await format(extractedDefinition, { parser: "typescript" });
-    result.typeDefinition = formatted;
+  // Handle arrays explicitly
+  let baseTypeText = typeText;
+  let isArray = false;
+  if (typeText.endsWith("[]")) {
+    baseTypeText = typeText.slice(0, -2);
+    isArray = true;
+  } else {
+    const arrayMatch = typeText.match(/^Array<(.*)>$/);
+    if (arrayMatch) {
+      baseTypeText = arrayMatch[1].trim();
+      isArray = true;
+    }
   }
 
-  return result;
+  if (isArray) {
+    const baseSymbol = extractInternalTypeReferenceSymbol(baseTypeText, contextNode);
+    if (baseSymbol) {
+      await parseType(baseTypeText, typeDependencies, contextNode, visited, baseSymbol);
+      const parsed: ParsedType = {
+        name: typeText,
+        definition: `type ${typeText} = ${baseTypeText}[];`,
+        dependencies: [baseTypeText],
+      };
+      typeDependencies[typeText] = parsed;
+      return parsed;
+    }
+
+    const baseSrc = extractTypeSrc(baseTypeText);
+
+    if (baseSrc) {
+      await parseType(baseTypeText, typeDependencies, contextNode);
+      const parsed: ParsedType = {
+        name: typeText,
+        definition: `type ${typeText} = ${baseTypeText}[];`,
+        dependencies: [baseTypeText],
+      };
+      typeDependencies[typeText] = parsed;
+      return parsed;
+    }
+  }
+
+  const symbol =
+    resolvedSymbol ??
+    (isTypeAlias(typeText, contextNode) || extractInternalTypeReferenceSymbol(typeText, contextNode)
+      ? extractInternalTypeReferenceSymbol(typeText, contextNode)
+      : undefined);
+
+  if (symbol) {
+    const decls = symbol.getDeclarations();
+
+    decls.forEach((decl) => {
+      decl.replaceWithText(decl.getText().replace(/export\s+/, ""));
+    });
+
+    if (decls.length > 0) {
+      const decl = decls[0];
+      const filePath = decl.getSourceFile().getFilePath();
+      if (filePath.includes("node_modules")) {
+        return { definition: typeText };
+      }
+
+      if (typeDependencies[typeText]) {
+        return typeDependencies[typeText];
+      }
+      if (visited.has(typeText)) {
+        return { name: typeText, definition: `type ${typeText} = any;`, dependencies: [] };
+      }
+
+      visited.add(typeText);
+      removeChildrenComments(decl);
+
+      let definition: string;
+      if (
+        Node.isInterfaceDeclaration(decl) ||
+        Node.isTypeAliasDeclaration(decl) ||
+        Node.isEnumDeclaration(decl) ||
+        Node.isClassDeclaration(decl)
+      ) {
+        definition = decl.getText({ includeJsDocComments: false }).replaceAll("\n\n", "\n");
+      } else {
+        definition = `type ${typeText} = ${typeText};`;
+      }
+
+      const dependenciesSet = new Set<string>();
+      const references = Array.from(new Set(definition.match(/\b([A-Z]\w*(?:\.\w+)*)\b/g) || []));
+
+      for (const ref of references) {
+        if (
+          ref === typeText ||
+          visited.has(ref) ||
+          PRESERVE_TYPE_NAMES.has(ref) ||
+          BUILTIN_TYPES.has(ref) ||
+          isImportedFromExternal(ref, decl)
+        ) {
+          continue;
+        }
+
+        const refSymbol = extractInternalTypeReferenceSymbol(ref, decl);
+        if (refSymbol) {
+          dependenciesSet.add(ref);
+          await parseType(ref, typeDependencies, decl, visited, refSymbol);
+        }
+      }
+
+      const formatted = await format(definition, { parser: "typescript" });
+
+      const parsed: ParsedType = {
+        name: typeText,
+        definition: formatted,
+        dependencies: Array.from(dependenciesSet),
+      };
+      typeDependencies[typeText] = parsed;
+      visited.delete(typeText);
+      return parsed;
+    }
+  }
+
+  return { definition: typeText };
 }
 
 /** Parses a single property symbol into a `ParsedProperty`. */
-async function parseProperty(prop: MorphSymbol, contextNode: Node, genericNames: Set<string>) {
+async function parseProperty(
+  prop: MorphSymbol,
+  contextNode: Node,
+  genericNames: Set<string>,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>
+) {
   const name = prop.getName();
 
   let description = "";
@@ -127,7 +259,13 @@ async function parseProperty(prop: MorphSymbol, contextNode: Node, genericNames:
     }
   }
 
-  const { type, flags } = await resolvePropertyType(prop, decl, contextNode, genericNames);
+  const { type, flags } = await resolvePropertyType(
+    prop,
+    decl,
+    contextNode,
+    genericNames,
+    typeDependencies
+  );
 
   const result: ParsedProperty = {
     name,

--- a/docgen/props/parsePropsInterface/resolver.ts
+++ b/docgen/props/parsePropsInterface/resolver.ts
@@ -2,34 +2,23 @@ import { type Symbol as MorphSymbol, Node, type Type, TypeFormatFlags } from "ts
 import { isTypeAlias, isTypeOriginatingFrom } from "./checker";
 import {
   LARGE_UNION_THRESHOLD,
-  MaybeParsed,
   ParsedPropertyFlags,
   PRESERVE_TYPE_NAMES,
-  TypeSrcMap,
+  ParsedType,
 } from "./defs";
-import {
-  extractInternalTypeReferenceSymbol,
-  extractRawTypeAnnotation,
-  extractTypeText,
-} from "./extractor";
+import { extractRawTypeAnnotation, extractTypeText } from "./extractor";
 import { parseType } from "./parser";
-import { computeAllReferences, getText, splitUnionParts, tryPreserveAnnotation } from "./utils";
+import { tryPreserveAnnotation, splitUnionParts } from "./utils";
 
 /**
- * Core type resolution logic. Determines how to represent a property's type
- * based on the rules:
- * - Preserve external types (MaterialSymbol, Snippet, etc.) as-is
- * - Resolve internal type aliases (like QBtnVariantOptions) to their values
- * - Show computed types for Omit/Exclude
- * - Preserve template literal syntax
- * - Show generic parameter names as-is
- * - For large unions (>10 members), show the alias name
+ * Core type resolution logic. Determines how to represent a property's type.
  */
 export async function resolvePropertyType(
   prop: MorphSymbol,
   decl: Node | undefined,
   contextNode: Node,
-  genericNames: Set<string>
+  genericNames: Set<string>,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>
 ) {
   const propType = prop.getTypeAtLocation(contextNode);
   const nonNullType = propType.getNonNullableType();
@@ -54,7 +43,11 @@ export async function resolvePropertyType(
     }
 
     if (elementRawAnnotation) {
-      const utilityType = await tryResolveUtilityTypes(elementRawAnnotation, contextNode);
+      const utilityType = await tryResolveUtilityTypes(
+        elementRawAnnotation,
+        contextNode,
+        typeDependencies
+      );
       if (utilityType) {
         return {
           type: utilityType.type,
@@ -62,7 +55,11 @@ export async function resolvePropertyType(
         };
       }
 
-      const preserved = await tryPreserveAnnotation(elementRawAnnotation, contextNode);
+      const preserved = await tryPreserveAnnotation(
+        elementRawAnnotation,
+        contextNode,
+        typeDependencies
+      );
 
       if (preserved) {
         return {
@@ -78,7 +75,9 @@ export async function resolvePropertyType(
         elementType,
         elementAliasSymbol,
         contextNode,
-        elementRawAnnotation
+        elementRawAnnotation,
+        typeDependencies,
+        decl
       );
       return {
         type: res,
@@ -91,7 +90,9 @@ export async function resolvePropertyType(
         elementType,
         contextNode,
         genericNames,
-        elementRawAnnotation
+        elementRawAnnotation,
+        typeDependencies,
+        decl
       );
       return {
         type: res,
@@ -101,7 +102,7 @@ export async function resolvePropertyType(
 
     const elementText = extractTypeText(elementType, contextNode);
     return {
-      type: await parseType(elementRawAnnotation ?? elementText),
+      type: await parseType(elementRawAnnotation ?? elementText, typeDependencies, contextNode),
       flags: ParsedPropertyFlags.ARRAY,
     };
   }
@@ -110,7 +111,7 @@ export async function resolvePropertyType(
   if (rawAnnotation && rawAnnotation.startsWith("Snippet")) {
     const params = resolveSnippetParams(rawAnnotation);
     return {
-      type: await parseType(params ?? "void"),
+      type: await parseType(params ?? "void", typeDependencies, contextNode),
       flags: ParsedPropertyFlags.SNIPPET,
     };
   }
@@ -126,17 +127,15 @@ export async function resolvePropertyType(
     const params = resolveSnippetParams(fullText);
 
     return {
-      type: await parseType(params ?? "void"),
+      type: await parseType(params ?? "void", typeDependencies, contextNode),
       flags: ParsedPropertyFlags.SNIPPET,
     };
   }
 
   // Check if the raw annotation references a preserved or external type
-  // (catches cases where alias info is lost during resolution, e.g. MaterialSymbol
-  // resolving to a 1000+ member union, or HTMLAnchorAttributes["target"] resolving
-  // to "_self" | "_blank" | "_parent" | "_top" | (string & {}))
   if (rawAnnotation) {
-    const utilityType = await tryResolveUtilityTypes(rawAnnotation, contextNode);
+    const utilityType = await tryResolveUtilityTypes(rawAnnotation, contextNode, typeDependencies);
+
     if (utilityType) {
       return {
         type: utilityType.type,
@@ -144,7 +143,8 @@ export async function resolvePropertyType(
       };
     }
 
-    const preserved = await tryPreserveAnnotation(rawAnnotation, contextNode);
+    const preserved = await tryPreserveAnnotation(rawAnnotation, contextNode, typeDependencies);
+
     if (preserved) {
       return {
         type: preserved,
@@ -153,7 +153,7 @@ export async function resolvePropertyType(
     }
   }
 
-  // Handle boolean types (Typescript resolves `boolean` as a `true` | `false` union)
+  // Handle boolean types
   if (
     nonNullType.isBoolean() ||
     nonNullType.isBooleanLiteral() ||
@@ -161,7 +161,7 @@ export async function resolvePropertyType(
       nonNullType.getUnionTypes().every((union) => union.isBooleanLiteral()))
   ) {
     return {
-      type: "boolean",
+      type: await parseType("boolean", typeDependencies, contextNode),
       flags: ParsedPropertyFlags.NONE,
     };
   }
@@ -169,7 +169,14 @@ export async function resolvePropertyType(
   // Handle union types
   if (nonNullType.isUnion()) {
     return {
-      type: await resolveUnionType(nonNullType, contextNode, genericNames, rawAnnotation),
+      type: await resolveUnionType(
+        nonNullType,
+        contextNode,
+        genericNames,
+        rawAnnotation,
+        typeDependencies,
+        decl
+      ),
       flags: ParsedPropertyFlags.NONE,
     };
   }
@@ -177,7 +184,7 @@ export async function resolvePropertyType(
   // Handle `keyof X` types and types that use a generic parameter
   if (rawAnnotation && (rawAnnotation.startsWith("keyof ") || genericNames.has(rawAnnotation))) {
     return {
-      type: await parseType(rawAnnotation),
+      type: await parseType(rawAnnotation, typeDependencies, contextNode),
       flags: ParsedPropertyFlags.NONE,
     };
   }
@@ -185,48 +192,52 @@ export async function resolvePropertyType(
   // Handle aliased types
   if (aliasSymbol) {
     return {
-      type: await resolveAliasedType(nonNullType, aliasSymbol, contextNode, rawAnnotation),
+      type: await resolveAliasedType(
+        nonNullType,
+        aliasSymbol,
+        contextNode,
+        rawAnnotation,
+        typeDependencies,
+        decl
+      ),
       flags: ParsedPropertyFlags.NONE,
     };
   }
 
   // Default: use the resolved type text
   return {
-    type: await parseType(resolvedText),
+    type: await parseType(resolvedText, typeDependencies, contextNode),
     flags: ParsedPropertyFlags.NONE,
   };
 }
 
 /**
- * Resolves a type that has an alias symbol. Determines whether to show
- * the alias name or its computed value based on external/internal status.
+ * Resolves a type that has an alias symbol.
  */
 async function resolveAliasedType(
   type: Type,
   aliasSymbol: MorphSymbol,
   contextNode: Node,
-  rawAnnotation: string | undefined
+  rawAnnotation: string | undefined,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>,
+  decl: Node | undefined
 ) {
   const aliasName = aliasSymbol.getName();
+  const checkNode = decl ?? contextNode;
 
   // Preserve well-known external types
   if (PRESERVE_TYPE_NAMES.has(aliasName)) {
-    return parseType(aliasName);
+    return parseType(aliasName, typeDependencies, checkNode);
   }
 
   // External types: keep as-is
   if (isTypeOriginatingFrom(type, "external")) {
-    const fullText = type.getText(contextNode, TypeFormatFlags.NoTruncation);
-    return parseType(fullText);
+    const fullText = type.getText(checkNode, TypeFormatFlags.NoTruncation);
+    return parseType(fullText, typeDependencies, checkNode);
   }
 
-  // Internal alias: resolve to the computed value
-  const resolvedText = extractTypeText(type, contextNode);
-  const computedTypes = {
-    [aliasName]: await parseType(resolvedText),
-    ...(await computeAllReferences(resolvedText, contextNode, new Set([aliasName]))),
-  };
-  return parseType(rawAnnotation ?? aliasName, computedTypes);
+  // Internal alias: resolve via parseType
+  return parseType(rawAnnotation ?? aliasName, typeDependencies, checkNode, new Set(), aliasSymbol);
 }
 
 /**
@@ -237,18 +248,16 @@ async function resolveUnionType(
   type: Type,
   contextNode: Node,
   genericNames: Set<string>,
-  rawAnnotation: string | undefined
-) {
+  rawAnnotation: string | undefined,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>,
+  decl: Node | undefined
+): Promise<ParsedType | ParsedType[]> {
+  const checkNode = decl ?? contextNode;
   const unionTypes = type.getUnionTypes();
-
-  // If the union is from a type alias, check if we should preserve the alias name
   const aliasSymbol = type.getAliasSymbol();
 
-  if (!aliasSymbol && rawAnnotation && isTypeAlias(rawAnnotation, contextNode)) {
-    const resolved = await resolveTypeAliasMembers(rawAnnotation, contextNode);
-    if (resolved) {
-      return resolved;
-    }
+  if (!aliasSymbol && rawAnnotation && isTypeAlias(rawAnnotation, checkNode)) {
+    return parseType(rawAnnotation, typeDependencies, checkNode);
   }
 
   if (aliasSymbol) {
@@ -256,252 +265,84 @@ async function resolveUnionType(
 
     // Preserve external types like MaterialSymbol or Snippet
     if (PRESERVE_TYPE_NAMES.has(aliasName)) {
-      return parseType(aliasName);
+      return parseType(aliasName, typeDependencies, checkNode);
     }
 
-    // Internal type alias: resolve to computed values using AST nodes to preserve references
+    // Internal type alias: resolve to the aliasName
     if (isTypeOriginatingFrom(type, "internal")) {
-      let rawMembersText: string[];
-      let typeNode;
-
-      const declarations = aliasSymbol.getDeclarations();
-      let decl: Node | undefined;
-
-      if (declarations.length) {
-        decl = declarations[0];
-
-        if (Node.isTypeAliasDeclaration(decl) || Node.isPropertySignature(decl)) {
-          typeNode = decl.getTypeNode();
-        }
-      }
-
-      if (Node.isTemplateLiteralTypeNode(typeNode)) {
-        const resolvedText = typeNode.getText({ includeJsDocComments: false });
-        const computedTypes = {
-          [aliasName]: await parseType(resolvedText),
-        };
-
-        const subRefs: string[] = [];
-        typeNode.forEachDescendant((node) => {
-          if (Node.isTypeReference(node)) {
-            subRefs.push(node.getText({ includeJsDocComments: false }));
-          }
-        });
-
-        for (const subRef of subRefs) {
-          Object.assign(
-            computedTypes,
-            await computeAllReferences(subRef, decl ?? contextNode, new Set([aliasName]))
-          );
-        }
-
-        return parseType(aliasName, computedTypes);
-      }
-
-      if (Node.isUnionTypeNode(typeNode)) {
-        rawMembersText = typeNode
-          .getTypeNodes()
-          .map((node) => node.getText({ includeJsDocComments: false }));
-      } else {
-        rawMembersText = unionTypes.map((unionType) => extractTypeText(unionType, contextNode));
-      }
-
-      const unionMembers = await Promise.all(rawMembersText.map((text) => parseType(text)));
-      const computedTypes = {
-        [aliasName]: unionMembers,
-      };
-
-      const visited = new Set([aliasName]);
-
-      for (const member of unionMembers) {
-        const text = getText(member);
-        Object.assign(
-          computedTypes,
-          await computeAllReferences(text, decl ?? contextNode, visited)
-        );
-      }
-
-      return parseType(aliasName, computedTypes);
+      return parseType(aliasName, typeDependencies, checkNode);
     }
 
     // Large unions (external): show the alias name
     if (unionTypes.length > LARGE_UNION_THRESHOLD) {
-      return parseType(aliasName, {
-        [aliasName]: await Promise.all(
-          unionTypes.map((union) => parseType(extractTypeText(union, contextNode)))
-        ),
-      });
+      return parseType(aliasName, typeDependencies, checkNode);
     }
   }
 
-  // If the raw annotation contains a union with diverse types (e.g. MaterialSymbol | `img:${string}`)
-  // parse each member individually
+  // If the raw annotation contains a union with diverse types
   if (rawAnnotation?.includes("|")) {
-    return resolveRawUnionAnnotation(rawAnnotation, contextNode, genericNames);
+    return resolveRawUnionAnnotation(rawAnnotation, checkNode, genericNames, typeDependencies);
   }
 
   // Simple union: map each member
   if (unionTypes.length <= LARGE_UNION_THRESHOLD) {
-    return Promise.all(unionTypes.map((union) => parseType(extractTypeText(union, contextNode))));
+    const resolvedParts = await Promise.all(
+      unionTypes.map((union) =>
+        parseType(extractTypeText(union, checkNode), typeDependencies, checkNode)
+      )
+    );
+    return resolvedParts.flat();
   }
 
   // Fallback for large unions without alias
-  return parseType(extractTypeText(type, contextNode));
+  return parseType(extractTypeText(type, checkNode), typeDependencies, checkNode);
 }
 
 /**
- * Resolves a type alias name to its union members as `ParsedType[]`.
- * Returns `undefined` if the alias doesn't resolve to a union.
- */
-async function resolveTypeAliasMembers(typeName: string, contextNode: Node) {
-  const symbol = extractInternalTypeReferenceSymbol(typeName, contextNode);
-  if (!symbol) {
-    return;
-  }
-  const declarations = symbol.getDeclarations();
-  if (!declarations.length) {
-    return;
-  }
-  const decl = declarations[0];
-  if (Node.isTypeAliasDeclaration(decl)) {
-    const aliasType = decl.getType();
-    const typeNode = decl.getTypeNode();
-
-    if (!typeNode) {
-      return;
-    }
-
-    if (aliasType.isUnion()) {
-      if (Node.isTemplateLiteralTypeNode(typeNode)) {
-        const resolvedText = typeNode.getText({ includeJsDocComments: false });
-        const computedTypes = {
-          [typeName]: await parseType(resolvedText),
-        };
-
-        const subRefs: string[] = [];
-        typeNode.forEachDescendant((node) => {
-          if (Node.isTypeReference(node)) {
-            subRefs.push(node.getText({ includeJsDocComments: false }));
-          }
-        });
-
-        for (const subRef of subRefs) {
-          Object.assign(
-            computedTypes,
-            await computeAllReferences(subRef, decl, new Set([typeName]))
-          );
-        }
-
-        return parseType(typeName, computedTypes);
-      }
-
-      let rawMembersText: string[];
-      if (Node.isUnionTypeNode(typeNode)) {
-        rawMembersText = typeNode
-          .getTypeNodes()
-          .map((node) => node.getText({ includeJsDocComments: false }));
-      } else {
-        rawMembersText = aliasType
-          .getUnionTypes()
-          .map((union) => extractTypeText(union, contextNode));
-      }
-
-      const unionMembers = await Promise.all(rawMembersText.map((text) => parseType(text)));
-      const computedTypes = {
-        [typeName]: unionMembers,
-      };
-
-      const visited = new Set([typeName]);
-      for (const member of unionMembers) {
-        const text = getText(member);
-        Object.assign(computedTypes, await computeAllReferences(text, decl, visited));
-      }
-
-      return parseType(typeName, computedTypes);
-    }
-
-    // Not a union, return the resolved text
-    const resolvedText = extractTypeText(aliasType, contextNode);
-    const computedTypes = {
-      [typeName]: await parseType(resolvedText),
-      ...(await computeAllReferences(resolvedText, decl, new Set([typeName]))),
-    };
-
-    return parseType(resolvedText, computedTypes);
-  }
-}
-
-/**
- * Parses a raw union annotation like `MaterialSymbol | \`img:${string}\``
- * into individual ParsedType entries, preserving external type names.
+ * Parses a raw union annotation into individual ParsedType entries.
  */
 async function resolveRawUnionAnnotation(
   rawAnnotation: string,
   contextNode: Node,
-  genericNames: Set<string>
-) {
+  genericNames: Set<string>,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>
+): Promise<ParsedType | ParsedType[]> {
   const parts = splitUnionParts(rawAnnotation);
 
   if (parts.length <= 1) {
-    return parseType(rawAnnotation);
+    return parseType(rawAnnotation, typeDependencies, contextNode);
   }
 
-  const parsedTypes: MaybeParsed[] = [];
+  const parsedTypes: (ParsedType | ParsedType[])[] = [];
 
   for (const part of parts) {
-    // Check if this part is a preservec external type
-    // or a generic or if it's a known external type reference
-    // (like HTMLAnchorAttributes["target"])
-
-    if (PRESERVE_TYPE_NAMES.has(part) || genericNames.has(part) || part in TypeSrcMap) {
-      parsedTypes.push(await parseType(part));
-      continue;
-    }
-
-    // Check if it references an internal type alias that should be resolved
-    if (isTypeAlias(part, contextNode)) {
-      const resolvedAlias = await resolveTypeAliasMembers(part, contextNode);
-
-      if (resolvedAlias) {
-        parsedTypes.push(resolvedAlias);
-        continue;
-      }
-    }
-
-    // Keep as-is (literals, template literals, primitives)
-    parsedTypes.push(await parseType(part));
+    parsedTypes.push(await parseType(part, typeDependencies, contextNode));
   }
 
-  return parsedTypes.length === 1 ? parsedTypes[0] : parsedTypes;
+  const flattened = parsedTypes.flat();
+  return flattened.length === 1 ? flattened[0] : flattened;
 }
 
 /**
- * Extracts the Snippet parameter type text from a full Snippet type string.
- * E.g. `Snippet<[{ expanded: boolean }]>` → `{ expanded: boolean }`.
- * Returns `undefined` for `Snippet` with no parameters.
- * Handles multiline Snippet annotations by normalizing whitespace.
+ * Extracts the Snippet parameter type text from a Snippet type string.
  */
 function resolveSnippetParams(typeText: string) {
-  // Normalize whitespace (multiline Snippet annotations)
   const normalized = typeText.replace(/\s+/g, " ").trim();
-
-  // Match Snippet<[...]> with possible whitespace
   const match = normalized.match(/^Snippet\s*<\s*\[\s*(.+?)\s*\]\s*>$/s);
   if (!match) {
     return;
   }
-
   return match[1].trim();
 }
 
 /**
  * Resolves typescript utility types (Omit, Exclude, Pick, Extract)
- * by parsing their inner target and parameters separately.
  */
 async function tryResolveUtilityTypes(
   rawAnnotation: string | undefined,
-  contextNode: Node
-): Promise<{ type: [MaybeParsed, MaybeParsed]; flag: ParsedPropertyFlags } | undefined> {
+  contextNode: Node,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>
+): Promise<{ type: [ParsedType, ParsedType]; flag: ParsedPropertyFlags } | undefined> {
   if (!rawAnnotation) {
     return undefined;
   }
@@ -510,13 +351,10 @@ async function tryResolveUtilityTypes(
   if (omitMatch) {
     const targetType = omitMatch[1].trim();
     const keys = omitMatch[2].trim();
-    const parsedTarget = await parseType(
-      targetType,
-      await computeAllReferences(targetType, contextNode)
-    );
-    const parsedKeys = await parseType(keys, await computeAllReferences(keys, contextNode));
+    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
+    const parsedKeys = await parseType(keys, typeDependencies, contextNode);
     return {
-      type: [parsedTarget, parsedKeys],
+      type: [parsedTarget as ParsedType, parsedKeys as ParsedType],
       flag: ParsedPropertyFlags.OMIT,
     };
   }
@@ -525,16 +363,10 @@ async function tryResolveUtilityTypes(
   if (excludeMatch) {
     const targetType = excludeMatch[1].trim();
     const excluded = excludeMatch[2].trim();
-    const parsedTarget = await parseType(
-      targetType,
-      await computeAllReferences(targetType, contextNode)
-    );
-    const parsedExcluded = await parseType(
-      excluded,
-      await computeAllReferences(excluded, contextNode)
-    );
+    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
+    const parsedExcluded = await parseType(excluded, typeDependencies, contextNode);
     return {
-      type: [parsedTarget, parsedExcluded],
+      type: [parsedTarget as ParsedType, parsedExcluded as ParsedType],
       flag: ParsedPropertyFlags.EXCLUDE,
     };
   }
@@ -543,13 +375,10 @@ async function tryResolveUtilityTypes(
   if (pickMatch) {
     const targetType = pickMatch[1].trim();
     const keys = pickMatch[2].trim();
-    const parsedTarget = await parseType(
-      targetType,
-      await computeAllReferences(targetType, contextNode)
-    );
-    const parsedKeys = await parseType(keys, await computeAllReferences(keys, contextNode));
+    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
+    const parsedKeys = await parseType(keys, typeDependencies, contextNode);
     return {
-      type: [parsedTarget, parsedKeys],
+      type: [parsedTarget as ParsedType, parsedKeys as ParsedType],
       flag: ParsedPropertyFlags.PICK,
     };
   }
@@ -558,16 +387,10 @@ async function tryResolveUtilityTypes(
   if (extractMatch) {
     const targetType = extractMatch[1].trim();
     const extracted = extractMatch[2].trim();
-    const parsedTarget = await parseType(
-      targetType,
-      await computeAllReferences(targetType, contextNode)
-    );
-    const parsedExtracted = await parseType(
-      extracted,
-      await computeAllReferences(extracted, contextNode)
-    );
+    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
+    const parsedExtracted = await parseType(extracted, typeDependencies, contextNode);
     return {
-      type: [parsedTarget, parsedExtracted],
+      type: [parsedTarget as ParsedType, parsedExtracted as ParsedType],
       flag: ParsedPropertyFlags.EXTRACT,
     };
   }

--- a/docgen/props/parsePropsInterface/utils.ts
+++ b/docgen/props/parsePropsInterface/utils.ts
@@ -1,17 +1,17 @@
-import { Node, SyntaxKind } from "ts-morph";
+import { Node } from "ts-morph";
 import { isImportedFromExternal } from "./checker";
-import { BUILTIN_TYPES, MaybeParsed, type ParsedType, PRESERVE_TYPE_NAMES } from "./defs";
-import { extractInternalTypeReferenceSymbol, extractTypeText } from "./extractor";
+import { type ParsedType, PRESERVE_TYPE_NAMES } from "./defs";
 import { parseType } from "./parser";
 
 /**
  * Attempts to preserve the raw type annotation as-is when it references
- * a preserved or external type. This catches cases where the alias info
- * is lost during type resolution (e.g. `MaterialSymbol` or `HTMLAnchorAttributes["target"]`).
- *
- * Returns the preserved result or `undefined` if the annotation should be resolved normally.
+ * a preserved or external type.
  */
-export async function tryPreserveAnnotation(rawAnnotation: string, contextNode: Node) {
+export async function tryPreserveAnnotation(
+  rawAnnotation: string,
+  contextNode: Node,
+  typeDependencies: Record<string, ParsedType | ParsedType[]>
+) {
   // Don't try to preserve if the annotation itself contains a top-level union
   if (splitUnionParts(rawAnnotation).length > 1) {
     return undefined;
@@ -19,12 +19,10 @@ export async function tryPreserveAnnotation(rawAnnotation: string, contextNode: 
 
   // Preserve inline template literals
   if (rawAnnotation.includes("`")) {
-    const computedTypes = await computeAllReferences(rawAnnotation, contextNode);
-
-    return parseType(rawAnnotation, computedTypes);
+    return parseType(rawAnnotation, typeDependencies, contextNode);
   }
 
-  // Extract the base type name (first identifier before `[`, `<`, or end)
+  // Extract the base type name
   const baseTypeMatch = rawAnnotation.match(/^(\w+)/);
   if (!baseTypeMatch) {
     return;
@@ -34,16 +32,14 @@ export async function tryPreserveAnnotation(rawAnnotation: string, contextNode: 
 
   // Check if the base is a directly preserved type name (e.g. "MaterialSymbol")
   if (PRESERVE_TYPE_NAMES.has(baseTypeName)) {
-    return parseType(rawAnnotation);
+    return parseType(rawAnnotation, typeDependencies, contextNode);
   }
 
   // Check if the base type is imported from an external package
-  // (e.g. HTMLAnchorAttributes["target"], MouseEventHandler<HTMLElement>)
   if (isImportedFromExternal(baseTypeName, contextNode)) {
-    return parseType(rawAnnotation);
+    return parseType(rawAnnotation, typeDependencies, contextNode);
   }
 
-  // Otherwise, fall through to normal resolution
   return;
 }
 
@@ -95,204 +91,25 @@ export function splitUnionParts(text: string) {
 }
 
 /**
- * Scans a type text for capitalized identifiers and attempts to resolve them
- * as internal type aliases or interfaces, returning a flattened map of all
- * referenced computed types.
- */
-export async function computeAllReferences(
-  text: string,
-  contextNode: Node,
-  visited = new Set<string>()
-) {
-  const result: NonNullable<ParsedType["computedTypes"]> = {};
-  const references = Array.from(new Set(text.match(/\b([A-Z]\w*(?:\.\w+)*)\b/g) || []));
-
-  for (const ref of references) {
-    if (
-      visited.has(ref) ||
-      PRESERVE_TYPE_NAMES.has(ref) ||
-      BUILTIN_TYPES.has(ref) ||
-      isImportedFromExternal(ref, contextNode)
-    ) {
-      continue;
-    }
-
-    const refSymbol = extractInternalTypeReferenceSymbol(ref, contextNode);
-    if (!refSymbol) {
-      continue;
-    }
-
-    const decls = refSymbol.getDeclarations();
-    if (!decls.length) {
-      continue;
-    }
-
-    const decl = decls[0];
-
-    const typeChecker = contextNode.getProject().getTypeChecker();
-    const refType = refSymbol.getDeclaredType() ?? typeChecker.getTypeAtLocation(decl);
-
-    visited.add(ref);
-
-    if (refType.isUnion()) {
-      let rawMembersText;
-      let typeNode;
-
-      if (Node.isTypeAliasDeclaration(decl) || Node.isPropertySignature(decl)) {
-        typeNode = decl.getTypeNode();
-      }
-
-      if (Node.isTemplateLiteralTypeNode(typeNode)) {
-        const text = typeNode.getText({ includeJsDocComments: false });
-        result[ref] = await parseType(text);
-
-        const subRefs: string[] = [];
-        typeNode.forEachDescendant((node) => {
-          if (Node.isTypeReference(node)) {
-            subRefs.push(node.getText({ includeJsDocComments: false }));
-          }
-        });
-
-        for (const subRef of subRefs) {
-          if (!visited.has(subRef)) {
-            Object.assign(result, await computeAllReferences(subRef, decl, visited));
-          }
-        }
-
-        continue;
-      }
-
-      if (Node.isUnionTypeNode(typeNode)) {
-        rawMembersText = typeNode
-          .getTypeNodes()
-          .map((node) => node.getText({ includeJsDocComments: false }));
-      } else {
-        rawMembersText = refType
-          .getUnionTypes()
-          .map((union) => extractTypeText(union, contextNode));
-      }
-
-      const unionMembers = await Promise.all(rawMembersText.map((text) => parseType(text)));
-      result[ref] = unionMembers;
-
-      for (const member of unionMembers) {
-        const text = getText(member);
-        Object.assign(result, await computeAllReferences(text, decl, visited));
-      }
-    } else if (
-      Node.isInterfaceDeclaration(decl) ||
-      Node.isTypeAliasDeclaration(decl) ||
-      Node.isEnumDeclaration(decl) ||
-      Node.isClassDeclaration(decl)
-    ) {
-      const name = decl.getName() ?? ref;
-
-      removeChildrenComments(decl);
-
-      const parsed: ParsedType = {
-        text: name,
-        typeDefinition: decl.getText({ includeJsDocComments: false }).replaceAll("\n\n", "\n"),
-      };
-      result[ref] = parsed;
-      Object.assign(
-        result,
-        await computeAllReferences(decl.getText({ includeJsDocComments: false }), decl, visited)
-      );
-    } else {
-      const refText = extractTypeText(refType, contextNode);
-      result[ref] = await parseType(refText);
-      Object.assign(result, await computeAllReferences(refText, decl, visited));
-    }
-  }
-
-  return result;
-}
-
-/**
- * Sorts the computed types by reference:
- * - The reference type comes last
- * - Types which don't reference other types come first
- */
-export function sortComputedTypes(
-  computedTypes: NonNullable<ParsedType["computedTypes"]>,
-  referenceType: string
-) {
-  const sorted: [string, MaybeParsed | MaybeParsed[]][] = [];
-  const visited = new Set<string>();
-  const visiting = new Set<string>();
-
-  const isReferenceType = (key: string) => {
-    return key === referenceType || key.replace(/^Q\./, "") === referenceType;
-  };
-
-  const references = (value: MaybeParsed | MaybeParsed[], targetKey: string) => {
-    const texts = Array.isArray(value) ? value.map(getText) : [getText(value)];
-    const escaped = targetKey.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-    const regex = new RegExp(`\\b${escaped}\\b`);
-    return texts.some((text) => regex.test(text));
-  };
-
-  const visit = (key: string) => {
-    if (visited.has(key)) {
-      return;
-    }
-    if (visiting.has(key)) {
-      // Cycle detected, break recursion
-      return;
-    }
-
-    visiting.add(key);
-
-    const value = computedTypes[key];
-    for (const otherKey of Object.keys(computedTypes)) {
-      if (otherKey === key || isReferenceType(otherKey)) {
-        continue;
-      }
-
-      if (references(value, otherKey)) {
-        visit(otherKey);
-      }
-    }
-
-    visiting.delete(key);
-    visited.add(key);
-    sorted.push([key, value]);
-  };
-
-  // 1. Visit all non-reference types first (standalone and their dependencies)
-  for (const key of Object.keys(computedTypes)) {
-    if (!isReferenceType(key)) {
-      visit(key);
-    }
-  }
-
-  // 2. Finally, visit the reference type itself
-  for (const key of Object.keys(computedTypes)) {
-    if (isReferenceType(key)) {
-      visit(key);
-    }
-  }
-
-  return sorted;
-}
-
-/**
  * Gets the text from a parsed type or a string.
  */
-export function getText(type: MaybeParsed) {
-  return typeof type === "string"
-    ? type
-    : type.text.endsWith("Props")
-      ? type.typeDefinition || type.text
-      : type.text;
+export function getText(type: ParsedType) {
+  if (typeof type === "string") {
+    return type;
+  }
+  if ("name" in type) {
+    return type.name;
+  }
+  return type.definition;
 }
 
-function removeChildrenComments(node: Node) {
-  node.forEachChild((child) => {
-    const comments = child.getChildrenOfKind(SyntaxKind.JSDoc);
-
-    if (comments.length) {
-      comments.forEach((comment) => comment.remove());
+export function removeChildrenComments(node: Node) {
+  if (Node.isJSDocable(node)) {
+    node.getJsDocs().forEach((comment) => comment.remove());
+  }
+  node.forEachDescendant((descendant) => {
+    if (Node.isJSDocable(descendant)) {
+      descendant.getJsDocs().forEach((comment) => comment.remove());
     }
   });
 }

--- a/docgen/props/worker.ts
+++ b/docgen/props/worker.ts
@@ -21,7 +21,7 @@ parentPort.on("message", async (workerData) => {
     const parsedInterface = await parseInterfaces(propsFilePath);
 
     let contents =
-      'import { MaybeParsed, ParsedGeneric, ParsedProperty } from "$docgen/props/parsePropsInterface/defs"\n\n';
+      'import { ParsedGeneric, ParsedProperty, ParsedType } from "$docgen/props/parsePropsInterface/defs"\n\n';
 
     Object.keys(parsedInterface).forEach((interfaceName) => {
       const parsedData = parsedInterface[interfaceName];
@@ -39,7 +39,7 @@ parentPort.on("message", async (workerData) => {
 
       const name = interfaceName.replace(/Props$/, "Docs");
 
-      contents += `export const ${name}DomAttributesConstraint: MaybeParsed | undefined = ${JSON.stringify(
+      contents += `export const ${name}DomAttributesConstraint: ParsedType | undefined = ${JSON.stringify(
         parsedData.domAttributesConstraint,
         null,
         2
@@ -59,6 +59,12 @@ parentPort.on("message", async (workerData) => {
 
       contents += `export const ${name}Snippets: ParsedProperty[] = ${JSON.stringify(
         snippets,
+        null,
+        2
+      )};\n\n`;
+
+      contents += `export const ${name}TypeDependencies: Record<string, ParsedType | ParsedType[]> = ${JSON.stringify(
+        parsedData.typeDependencies,
         null,
         2
       )};\n\n`;

--- a/src/docs/QApi.svelte
+++ b/src/docs/QApi.svelte
@@ -16,15 +16,15 @@
   import { capitalize, escape } from "$utils";
   import type { QComponentDocs, QComponentEvent, QComponentMethod } from "$docs";
   import {
-    type MaybeParsed,
     type ParsedProperty,
     ParsedPropertyFlags,
+    type ParsedType,
   } from "$docgen/props/parsePropsInterface/defs";
   import { docsCtx } from "./QDocs.svelte";
 
   type TabableDocsKey = Exclude<
     keyof QComponentDocs["docs"],
-    "generics" | "domAttributesConstraint"
+    "generics" | "domAttributesConstraint" | "typeDependencies"
   >;
 
   // #region:    --- Context
@@ -33,10 +33,7 @@
   // #endregion: --- Context
 
   // #region:    --- Reactive variables
-  let activeApiTabs: Exclude<
-    keyof QComponentDocs["docs"],
-    "generics" | "domAttributesConstraint"
-  >[] = $state(componentDocs.map(() => "props"));
+  let activeApiTabs: TabableDocsKey[] = $state(componentDocs.map(() => "props"));
   let tooltipGeneration = 0;
   let tooltipTeardowns: (() => unknown)[] = [];
   // #endregion: --- Reactive variables
@@ -68,71 +65,58 @@
     }
   }
 
-  function getType(type: string) {
-    const getDef = (item: MaybeParsed) => {
-      if (typeof item === "string") {
-        return undefined;
+  function getFullTypeDefinition(typeName: string, docs: QComponentDocs["docs"]): string {
+    // This is not a reactive variable so we can safely ignore this svelte lint rule
+    // eslint-disable-next-line svelte/prefer-svelte-reactivity
+    const visited = new Set<string>();
+    const definitions: string[] = [];
+
+    function collect(name: string) {
+      if (visited.has(name)) {
+        return;
+      }
+      visited.add(name);
+
+      const dep = docs.typeDependencies?.[name];
+      if (!dep) {
+        return;
       }
 
-      return item.text === type ? item.typeDefinition : undefined;
-    };
+      if (Array.isArray(dep)) {
+        for (const item of dep) {
+          if ("name" in item) {
+            collect(item.name);
+          }
+        }
+      } else {
+        if ("dependencies" in dep && dep.dependencies) {
+          for (const child of dep.dependencies) {
+            collect(child);
+          }
+        }
+        if ("definition" in dep) {
+          definitions.push(dep.definition);
+        }
+      }
+    }
 
+    collect(typeName);
+
+    const trimmedDefs = definitions.map((def) => def.trim());
+    const mainDef = trimmedDefs.pop();
+    if (!mainDef) {
+      return "";
+    }
+    if (trimmedDefs.length === 0) {
+      return mainDef;
+    }
+    return `${trimmedDefs.join("\n")}\n\n${mainDef}`;
+  }
+
+  function getType(type: string) {
     for (const QDocument of componentDocs) {
-      const { docs } = QDocument;
-
-      for (const [_name, doc] of Object.entries(docs)) {
-        if (!doc) {
-          continue;
-        }
-
-        if (!Array.isArray(doc)) {
-          // This is a DOM Attribute constraint definition
-          const res = getDef(doc);
-
-          if (res) {
-            return res;
-          }
-
-          continue;
-        }
-
-        for (const item of doc) {
-          if ("constraint" in item && item.constraint) {
-            const { constraint } = item;
-
-            const res = getDef(constraint);
-
-            if (res) {
-              return res;
-            }
-
-            continue;
-          }
-
-          if ("flags" in item) {
-            const { type: itemType } = item;
-
-            if (Array.isArray(itemType)) {
-              for (const typeOfItem of itemType) {
-                const res = getDef(typeOfItem);
-
-                if (res) {
-                  return res;
-                }
-              }
-
-              continue;
-            }
-
-            const res = getDef(itemType);
-
-            if (res) {
-              return res;
-            }
-
-            continue;
-          }
-        }
+      if (QDocument.docs.typeDependencies && type in QDocument.docs.typeDependencies) {
+        return getFullTypeDefinition(type, QDocument.docs);
       }
     }
 
@@ -141,7 +125,8 @@
 
   function getTabableEntries(QDocument: QComponentDocs) {
     return Object.entries(QDocument.docs).filter(
-      ([name]) => name !== "generics" && name !== "domAttributesConstraint"
+      ([name]) =>
+        name !== "generics" && name !== "domAttributesConstraint" && name !== "typeDependencies"
     ) as [TabableDocsKey, QComponentDocs["docs"][TabableDocsKey]][];
   }
 
@@ -186,6 +171,19 @@
     return `<${tag}${classString}${dataAttrs}${linkAttrs}>${spanContent}</${tag}>`;
   }
 
+  function renderType(t: ParsedType) {
+    const isNamed = "name" in t;
+    const text = isNamed ? t.name : t.definition;
+    const typeSrc = "typeSrc" in t && t.typeSrc ? t.typeSrc : "";
+
+    return inSpan(escape(text), {
+      typeStyle: true,
+      isClickable: isNamed,
+      typeSrc,
+      typeName: isNamed ? t.name : "",
+    });
+  }
+
   function prepareHeaderForGenericsAndConstraints(name: string, docs: QComponentDocs["docs"]) {
     let content = `<pre>`;
 
@@ -198,17 +196,8 @@
         let genericContent = inSpan(generic.name, { typeStyle: true });
 
         if (generic.constraint) {
-          const { constraint } = generic;
-          const isObject = typeof constraint !== "string";
-          const text = isObject ? constraint.text : constraint;
-
           genericContent += inSpan(" extends ", { typeStyle: true }).concat(
-            inSpan(escape(text), {
-              typeStyle: true,
-              isClickable: isObject,
-              typeSrc: isObject ? constraint.typeSrc : "",
-              typeName: text,
-            })
+            renderType(generic.constraint)
           );
         }
 
@@ -222,17 +211,7 @@
 
     if (docs.domAttributesConstraint) {
       content += inSpan(" extends ", { typeStyle: true });
-
-      const constraint = docs.domAttributesConstraint;
-      const isObject = typeof constraint !== "string";
-      const text = isObject ? constraint.text : constraint;
-
-      content += inSpan(escape(text), {
-        typeStyle: true,
-        isClickable: isObject,
-        typeSrc: isObject ? constraint.typeSrc : "",
-        typeName: text,
-      });
+      content += renderType(docs.domAttributesConstraint);
     }
 
     content += `</pre>`;
@@ -250,38 +229,12 @@
     content += inSpan("(", { typeStyle: true });
 
     if (Array.isArray(snippet.type)) {
-      content += inSpan("{ ", { typeStyle: true });
-
-      content += snippet.type
-        .map((arg) => {
-          const isObject = typeof arg !== "string";
-          const text = isObject ? arg.text : arg;
-
-          return inSpan(escape(text)).concat(
-            inSpan(": "),
-            inSpan(escape(text), {
-              typeStyle: true,
-              isClickable: isObject,
-              typeSrc: isObject ? arg.typeSrc : "",
-              typeName: text,
-            })
-          );
-        })
-        .join(", ");
-
-      content += inSpan(" }", { typeStyle: true });
+      content += snippet.type.map(renderType).join(" | ");
     } else {
       const { type } = snippet;
-      const isObject = typeof type !== "string";
-      const text = isObject ? type.text : type;
-
+      const text = "name" in type ? type.name : type.definition;
       if (text !== "void") {
-        content += inSpan(escape(text), {
-          typeStyle: true,
-          isClickable: isObject,
-          typeSrc: isObject ? type.typeSrc : "",
-          typeName: text,
-        });
+        content += renderType(type);
       }
     }
 
@@ -329,53 +282,14 @@
 
       content += inSpan(utilityName, { typeStyle: true });
       content += inSpan("<", { typeStyle: true });
-
-      const targetIsObject = typeof target !== "string";
-      const targetText = targetIsObject ? target.text : target;
-      content += inSpan(escape(targetText), {
-        typeStyle: true,
-        isClickable: targetIsObject,
-        typeSrc: targetIsObject ? target.typeSrc : "",
-        typeName: targetText,
-      });
-
+      content += renderType(target);
       content += inSpan(", ", { typeStyle: true });
-
-      const paramIsObject = typeof param !== "string";
-      const paramText = paramIsObject ? param.text : param;
-      content += inSpan(escape(paramText), {
-        typeStyle: true,
-        isClickable: paramIsObject,
-        typeSrc: paramIsObject ? param.typeSrc : "",
-        typeName: paramText,
-      });
-
+      content += renderType(param);
       content += inSpan(">", { typeStyle: true });
     } else if (Array.isArray(prop.type)) {
-      content += prop.type
-        .map((type) => {
-          const isObject = typeof type !== "string";
-          const text = isObject ? type.text : type;
-
-          return inSpan(escape(text), {
-            typeStyle: true,
-            isClickable: isObject,
-            typeSrc: isObject ? type.typeSrc : "",
-            typeName: text,
-          });
-        })
-        .join(" | ");
+      content += prop.type.map(renderType).join(" | ");
     } else {
-      const { type } = prop;
-      const isObject = typeof type !== "string";
-      const text = isObject ? type.text : type;
-
-      content += inSpan(escape(text), {
-        typeStyle: true,
-        isClickable: isObject,
-        typeSrc: isObject ? type.typeSrc : "",
-        typeName: text,
-      });
+      content += renderType(prop.type);
     }
 
     if (hasFlag(prop, "array")) {

--- a/src/docs/types.ts
+++ b/src/docs/types.ts
@@ -1,15 +1,16 @@
-import { MaybeParsed, ParsedGeneric, ParsedProperty } from "$docgen/props/parsePropsInterface/defs";
+import { ParsedGeneric, ParsedProperty, ParsedType } from "$docgen/props/parsePropsInterface/defs";
 
 export interface QComponentDocs {
   name: string;
   description: string;
   docs: {
     generics: ParsedGeneric[];
-    domAttributesConstraint: MaybeParsed | undefined;
+    domAttributesConstraint: ParsedType | undefined;
     props: ParsedProperty[];
     snippets: ParsedProperty[];
     methods: QComponentMethod[];
     events: QComponentEvent[];
+    typeDependencies: Record<string, ParsedType | ParsedType[]>;
   };
 }
 

--- a/src/lib/components/avatar/docs.ts
+++ b/src/lib/components/avatar/docs.ts
@@ -4,6 +4,7 @@ import {
   QAvatarDocsSnippets,
   QAvatarDocsDomAttributesConstraint,
   QAvatarDocsGenerics,
+  QAvatarDocsTypeDependencies,
 } from "./docs.props";
 
 export const QAvatarDocs: QComponentDocs = {
@@ -23,5 +24,6 @@ export const QAvatarDocs: QComponentDocs = {
         description: "Emitted when the user clicks on the avatar.",
       },
     ],
+    typeDependencies: QAvatarDocsTypeDependencies,
   },
 };

--- a/src/lib/components/breadcrumbs/docs.ts
+++ b/src/lib/components/breadcrumbs/docs.ts
@@ -4,6 +4,7 @@ import {
   QBreadcrumbsDocsSnippets,
   QBreadcrumbsDocsGenerics,
   QBreadcrumbsDocsDomAttributesConstraint,
+  QBreadcrumbsDocsTypeDependencies,
 } from "./docs.props";
 
 export const QBreadcrumbsDocs: QComponentDocs = {
@@ -17,5 +18,6 @@ export const QBreadcrumbsDocs: QComponentDocs = {
     snippets: QBreadcrumbsDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QBreadcrumbsDocsTypeDependencies,
   },
 };

--- a/src/lib/components/button/docs.ts
+++ b/src/lib/components/button/docs.ts
@@ -4,6 +4,7 @@ import {
   QBtnDocsGenerics,
   QBtnDocsProps,
   QBtnDocsSnippets,
+  QBtnDocsTypeDependencies,
 } from "./docs.props";
 
 export const QBtnDocs: QComponentDocs = {
@@ -23,5 +24,6 @@ export const QBtnDocs: QComponentDocs = {
         description: "Emitted when the user clicks on the button.",
       },
     ],
+    typeDependencies: QBtnDocsTypeDependencies,
   },
 };

--- a/src/lib/components/card/docs.ts
+++ b/src/lib/components/card/docs.ts
@@ -12,6 +12,9 @@ import {
   QCardSectionDocsSnippets,
   QCardSectionDocsGenerics,
   QCardSectionDocsDomAttributesConstraint,
+  QCardActionsDocsTypeDependencies,
+  QCardDocsTypeDependencies,
+  QCardSectionDocsTypeDependencies,
 } from "./docs.props";
 
 export const QCardDocs: QComponentDocs = {
@@ -25,6 +28,7 @@ export const QCardDocs: QComponentDocs = {
     snippets: QCardDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QCardActionsDocsTypeDependencies,
   },
 };
 
@@ -38,6 +42,7 @@ export const QCardSectionDocs: QComponentDocs = {
     snippets: QCardSectionDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QCardDocsTypeDependencies,
   },
 };
 
@@ -51,5 +56,6 @@ export const QCardActionsDocs: QComponentDocs = {
     snippets: QCardActionsDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QCardActionsDocsTypeDependencies,
   },
 };

--- a/src/lib/components/card/docs.ts
+++ b/src/lib/components/card/docs.ts
@@ -28,7 +28,7 @@ export const QCardDocs: QComponentDocs = {
     snippets: QCardDocsSnippets,
     methods: [],
     events: [],
-    typeDependencies: QCardActionsDocsTypeDependencies,
+    typeDependencies: QCardDocsTypeDependencies,
   },
 };
 
@@ -42,7 +42,7 @@ export const QCardSectionDocs: QComponentDocs = {
     snippets: QCardSectionDocsSnippets,
     methods: [],
     events: [],
-    typeDependencies: QCardDocsTypeDependencies,
+    typeDependencies: QCardSectionDocsTypeDependencies,
   },
 };
 

--- a/src/lib/components/checkbox/docs.ts
+++ b/src/lib/components/checkbox/docs.ts
@@ -4,6 +4,7 @@ import {
   QCheckboxDocsSnippets,
   QCheckboxDocsDomAttributesConstraint,
   QCheckboxDocsGenerics,
+  QCheckboxDocsTypeDependencies,
 } from "./docs.props";
 
 export const QCheckboxDocs: QComponentDocs = {
@@ -22,5 +23,6 @@ export const QCheckboxDocs: QComponentDocs = {
         description: "Emitted when the checkbox is checked or unchecked.",
       },
     ],
+    typeDependencies: QCheckboxDocsTypeDependencies,
   },
 };

--- a/src/lib/components/chip/docs.ts
+++ b/src/lib/components/chip/docs.ts
@@ -4,6 +4,7 @@ import {
   QChipDocsSnippets,
   QChipDocsDomAttributesConstraint,
   QChipDocsGenerics,
+  QChipDocsTypeDependencies,
 } from "./docs.props";
 
 export const QChipDocs: QComponentDocs = {
@@ -23,5 +24,6 @@ export const QChipDocs: QComponentDocs = {
         description: "Emitted when the user clicks on the chip.",
       },
     ],
+    typeDependencies: QChipDocsTypeDependencies,
   },
 };

--- a/src/lib/components/dialog/docs.ts
+++ b/src/lib/components/dialog/docs.ts
@@ -4,6 +4,7 @@ import {
   QDialogDocsSnippets,
   QDialogDocsDomAttributesConstraint,
   QDialogDocsGenerics,
+  QDialogDocsTypeDependencies,
 } from "./docs.props";
 
 export const QDialogDocs: QComponentDocs = {
@@ -16,5 +17,6 @@ export const QDialogDocs: QComponentDocs = {
     snippets: QDialogDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QDialogDocsTypeDependencies,
   },
 };

--- a/src/lib/components/drawer/docs.ts
+++ b/src/lib/components/drawer/docs.ts
@@ -4,6 +4,7 @@ import {
   QDrawerDocsSnippets,
   QDrawerDocsDomAttributesConstraint,
   QDrawerDocsGenerics,
+  QDrawerDocsTypeDependencies,
 } from "./docs.props";
 
 export const QDrawerDocs: QComponentDocs = {
@@ -16,5 +17,6 @@ export const QDrawerDocs: QComponentDocs = {
     snippets: QDrawerDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QDrawerDocsTypeDependencies,
   },
 };

--- a/src/lib/components/expansion-item/docs.ts
+++ b/src/lib/components/expansion-item/docs.ts
@@ -4,6 +4,7 @@ import {
   QExpansionItemDocsSnippets,
   QExpansionItemDocsDomAttributesConstraint,
   QExpansionItemDocsGenerics,
+  QExpansionItemDocsTypeDependencies,
 } from "./docs.props";
 
 export const QExpansionItemDocs: QComponentDocs = {
@@ -23,5 +24,6 @@ export const QExpansionItemDocs: QComponentDocs = {
         description: "Emitted when the user clicks on the expansion item.",
       },
     ],
+    typeDependencies: QExpansionItemDocsTypeDependencies,
   },
 };

--- a/src/lib/components/footer/docs.ts
+++ b/src/lib/components/footer/docs.ts
@@ -4,6 +4,7 @@ import {
   QFooterDocsSnippets,
   QFooterDocsDomAttributesConstraint,
   QFooterDocsGenerics,
+  QFooterDocsTypeDependencies,
 } from "./docs.props";
 
 export const QFooterDocs: QComponentDocs = {
@@ -17,5 +18,6 @@ export const QFooterDocs: QComponentDocs = {
     snippets: QFooterDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QFooterDocsTypeDependencies,
   },
 };

--- a/src/lib/components/header/docs.ts
+++ b/src/lib/components/header/docs.ts
@@ -4,6 +4,7 @@ import {
   QHeaderDocsSnippets,
   QHeaderDocsDomAttributesConstraint,
   QHeaderDocsGenerics,
+  QHeaderDocsTypeDependencies,
 } from "./docs.props";
 
 export const QHeaderDocs: QComponentDocs = {
@@ -17,5 +18,6 @@ export const QHeaderDocs: QComponentDocs = {
     snippets: QHeaderDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QHeaderDocsTypeDependencies,
   },
 };

--- a/src/lib/components/icon/docs.ts
+++ b/src/lib/components/icon/docs.ts
@@ -4,6 +4,7 @@ import {
   QIconDocsSnippets,
   QIconDocsDomAttributesConstraint,
   QIconDocsGenerics,
+  QIconDocsTypeDependencies,
 } from "./docs.props";
 
 export const QIconDocs: QComponentDocs = {
@@ -17,5 +18,6 @@ export const QIconDocs: QComponentDocs = {
     snippets: QIconDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QIconDocsTypeDependencies,
   },
 };

--- a/src/lib/components/input/docs.ts
+++ b/src/lib/components/input/docs.ts
@@ -4,6 +4,7 @@ import {
   QInputDocsSnippets,
   QInputDocsDomAttributesConstraint,
   QInputDocsGenerics,
+  QInputDocsTypeDependencies,
 } from "./docs.props";
 
 export const QInputDocs: QComponentDocs = {
@@ -23,5 +24,6 @@ export const QInputDocs: QComponentDocs = {
         description: "Native input event from the inner input element.",
       },
     ],
+    typeDependencies: QInputDocsTypeDependencies,
   },
 };

--- a/src/lib/components/layout/docs.ts
+++ b/src/lib/components/layout/docs.ts
@@ -4,6 +4,7 @@ import {
   QLayoutDocsSnippets,
   QLayoutDocsDomAttributesConstraint,
   QLayoutDocsGenerics,
+  QLayoutDocsTypeDependencies,
 } from "./docs.props";
 
 export const QLayoutDocs: QComponentDocs = {
@@ -17,5 +18,6 @@ export const QLayoutDocs: QComponentDocs = {
     snippets: QLayoutDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QLayoutDocsTypeDependencies,
   },
 };

--- a/src/lib/components/list/docs.ts
+++ b/src/lib/components/list/docs.ts
@@ -12,6 +12,9 @@ import {
   QListDocsSnippets,
   QListDocsDomAttributesConstraint,
   QListDocsGenerics,
+  QItemDocsTypeDependencies,
+  QItemSectionDocsTypeDependencies,
+  QListDocsTypeDependencies,
 } from "./docs.props";
 
 export const QListDocs: QComponentDocs = {
@@ -25,6 +28,7 @@ export const QListDocs: QComponentDocs = {
     snippets: QListDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QListDocsTypeDependencies,
   },
 };
 
@@ -39,6 +43,7 @@ export const QItemDocs: QComponentDocs = {
     snippets: QItemDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QItemDocsTypeDependencies,
   },
 };
 
@@ -53,5 +58,6 @@ export const QItemSectionDocs: QComponentDocs = {
     snippets: QItemSectionDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QItemSectionDocsTypeDependencies,
   },
 };

--- a/src/lib/components/menu/docs.ts
+++ b/src/lib/components/menu/docs.ts
@@ -4,6 +4,7 @@ import {
   QMenuDocsSnippets,
   QMenuDocsDomAttributesConstraint,
   QMenuDocsGenerics,
+  QMenuDocsTypeDependencies,
 } from "./docs.props";
 
 export const QMenuDocs: QComponentDocs = {
@@ -33,5 +34,6 @@ export const QMenuDocs: QComponentDocs = {
       },
     ],
     events: [],
+    typeDependencies: QMenuDocsTypeDependencies,
   },
 };

--- a/src/lib/components/progress/docs.ts
+++ b/src/lib/components/progress/docs.ts
@@ -8,6 +8,8 @@ import {
   QCircularProgressDocsSnippets,
   QCircularProgressDocsDomAttributesConstraint,
   QCircularProgressDocsGenerics,
+  QLinearProgressDocsTypeDependencies,
+  QCircularProgressDocsTypeDependencies,
 } from "./docs.props";
 
 export const QLinearProgressDocs: QComponentDocs = {
@@ -21,6 +23,7 @@ export const QLinearProgressDocs: QComponentDocs = {
     snippets: QLinearProgressDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QLinearProgressDocsTypeDependencies,
   },
 };
 
@@ -35,5 +38,6 @@ export const QCircularProgressDocs: QComponentDocs = {
     snippets: QCircularProgressDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QCircularProgressDocsTypeDependencies,
   },
 };

--- a/src/lib/components/radio/docs.ts
+++ b/src/lib/components/radio/docs.ts
@@ -4,6 +4,7 @@ import {
   QRadioDocsSnippets,
   QRadioDocsDomAttributesConstraint,
   QRadioDocsGenerics,
+  QRadioDocsTypeDependencies,
 } from "./docs.props";
 
 export const QRadioDocs: QComponentDocs = {
@@ -22,5 +23,6 @@ export const QRadioDocs: QComponentDocs = {
         description: "Emitted when the radio button is selected.",
       },
     ],
+    typeDependencies: QRadioDocsTypeDependencies,
   },
 };

--- a/src/lib/components/railbar/docs.ts
+++ b/src/lib/components/railbar/docs.ts
@@ -4,6 +4,7 @@ import {
   QRailbarDocsSnippets,
   QRailbarDocsDomAttributesConstraint,
   QRailbarDocsGenerics,
+  QRailbarDocsTypeDependencies,
 } from "./docs.props";
 
 export const QRailbarDocs: QComponentDocs = {
@@ -17,5 +18,6 @@ export const QRailbarDocs: QComponentDocs = {
     snippets: QRailbarDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QRailbarDocsTypeDependencies,
   },
 };

--- a/src/lib/components/select/docs.ts
+++ b/src/lib/components/select/docs.ts
@@ -4,6 +4,7 @@ import {
   QSelectDocsSnippets,
   QSelectDocsDomAttributesConstraint,
   QSelectDocsGenerics,
+  QSelectDocsTypeDependencies,
 } from "./docs.props";
 
 export const QSelectDocs: QComponentDocs = {
@@ -23,5 +24,6 @@ export const QSelectDocs: QComponentDocs = {
         description: "Emitted when the value of the select component changes.",
       },
     ],
+    typeDependencies: QSelectDocsTypeDependencies,
   },
 };

--- a/src/lib/components/separator/docs.ts
+++ b/src/lib/components/separator/docs.ts
@@ -8,6 +8,8 @@ import {
   QSeparatorHorizontalDocsSnippets,
   QSeparatorHorizontalDocsDomAttributesConstraint,
   QSeparatorHorizontalDocsGenerics,
+  QSeparatorVerticalDocsTypeDependencies,
+  QSeparatorHorizontalDocsTypeDependencies,
 } from "./docs.props";
 
 export const QSeparatorVerticalDocs: QComponentDocs = {
@@ -21,6 +23,7 @@ export const QSeparatorVerticalDocs: QComponentDocs = {
     snippets: QSeparatorVerticalDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QSeparatorVerticalDocsTypeDependencies,
   },
 };
 
@@ -35,5 +38,6 @@ export const QSeparatorHorizontalDocs: QComponentDocs = {
     snippets: QSeparatorHorizontalDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QSeparatorHorizontalDocsTypeDependencies,
   },
 };

--- a/src/lib/components/switch/docs.ts
+++ b/src/lib/components/switch/docs.ts
@@ -4,6 +4,7 @@ import {
   QSwitchDocsSnippets,
   QSwitchDocsDomAttributesConstraint,
   QSwitchDocsGenerics,
+  QSwitchDocsTypeDependencies,
 } from "./docs.props";
 
 export const QSwitchDocs: QComponentDocs = {
@@ -23,5 +24,6 @@ export const QSwitchDocs: QComponentDocs = {
         description: "Emitted when the user changes the value of the toggle.",
       },
     ],
+    typeDependencies: QSwitchDocsTypeDependencies,
   },
 };

--- a/src/lib/components/table/docs.ts
+++ b/src/lib/components/table/docs.ts
@@ -4,6 +4,7 @@ import {
   QTableDocsSnippets,
   QTableDocsDomAttributesConstraint,
   QTableDocsGenerics,
+  QTableDocsTypeDependencies,
 } from "./docs.props";
 
 export const QTableDocs: QComponentDocs = {
@@ -16,5 +17,6 @@ export const QTableDocs: QComponentDocs = {
     snippets: QTableDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QTableDocsTypeDependencies,
   },
 };

--- a/src/lib/components/tabs/docs.ts
+++ b/src/lib/components/tabs/docs.ts
@@ -8,6 +8,8 @@ import {
   QTabsDocsSnippets,
   QTabsDocsDomAttributesConstraint,
   QTabsDocsGenerics,
+  QTabDocsTypeDependencies,
+  QTabsDocsTypeDependencies,
 } from "./docs.props";
 
 export const QTabsDocs: QComponentDocs = {
@@ -21,6 +23,7 @@ export const QTabsDocs: QComponentDocs = {
     snippets: QTabsDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QTabsDocsTypeDependencies,
   },
 };
 
@@ -35,5 +38,6 @@ export const QTabDocs: QComponentDocs = {
     snippets: QTabDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QTabDocsTypeDependencies,
   },
 };

--- a/src/lib/components/toolbar/docs.ts
+++ b/src/lib/components/toolbar/docs.ts
@@ -8,6 +8,8 @@ import {
   QToolbarTitleDocsSnippets,
   QToolbarTitleDocsDomAttributesConstraint,
   QToolbarTitleDocsGenerics,
+  QToolbarDocsTypeDependencies,
+  QToolbarTitleDocsTypeDependencies,
 } from "./docs.props";
 
 export const QToolbarDocs: QComponentDocs = {
@@ -21,6 +23,7 @@ export const QToolbarDocs: QComponentDocs = {
     snippets: QToolbarDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QToolbarDocsTypeDependencies,
   },
 };
 
@@ -35,5 +38,6 @@ export const QToolbarTitleDocs: QComponentDocs = {
     snippets: QToolbarTitleDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QToolbarTitleDocsTypeDependencies,
   },
 };

--- a/src/lib/components/tooltip/docs.ts
+++ b/src/lib/components/tooltip/docs.ts
@@ -4,6 +4,7 @@ import {
   QTooltipDocsSnippets,
   QTooltipDocsDomAttributesConstraint,
   QTooltipDocsGenerics,
+  QTooltipDocsTypeDependencies,
 } from "./docs.props";
 
 export const QTooltipDocs: QComponentDocs = {
@@ -17,5 +18,6 @@ export const QTooltipDocs: QComponentDocs = {
     snippets: QTooltipDocsSnippets,
     methods: [],
     events: [],
+    typeDependencies: QTooltipDocsTypeDependencies,
   },
 };


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [x] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Improve interface parser to avoid duplication and complex debugging
- Handle more types cases (like `Snippet` linking to svelte's docs or some DOM types like `MouseHandler` linking to MDN `MouseEvent` page)

This is probably the second to last PR on this parser. The last thing to refactor is taking function types into account (e.g. the type for the `onFilter` property on `QInput`)

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
