### PR TITLE
refacor: improve prop parsing with dynamic defaults and fix `extends` types parsing

### DIFF
--- a/docgen/props/parsePropsInterface/checker.ts
+++ b/docgen/props/parsePropsInterface/checker.ts
@@ -10,24 +10,6 @@ export function isPropertyOptional(decl: Node) {
   return false;
 }
 
-/** Extracts whether the property is bindable from JSDoc, with the `@bindable` tag. */
-export function isPropertyBindable(decl: Node): boolean {
-  if (!Node.isJSDocable(decl)) {
-    return false;
-  }
-
-  const jsDocs = decl.getJsDocs();
-  if (jsDocs.length === 0) {
-    return false;
-  }
-
-  const doc = jsDocs[0];
-  const tags = doc.getTags();
-  const bindableTag = tags.find((tag) => tag.getTagName() === "bindable");
-
-  return !!bindableTag;
-}
-
 /**
  * Checks if a type name is imported from an external package
  * (Svelte, Material Symbols) by inspecting the source file's imports.

--- a/docgen/props/parsePropsInterface/defaults.ts
+++ b/docgen/props/parsePropsInterface/defaults.ts
@@ -1,0 +1,83 @@
+import { readFile } from "node:fs/promises";
+import { parse } from "svelte/compiler";
+import { ParsedDefaults } from "./defs";
+
+export async function parseDefaults(svelteFile: string) {
+  let content: string | undefined;
+  const result: ParsedDefaults = new Map();
+
+  try {
+    content = await readFile(svelteFile, "utf-8");
+  } catch (_err) {
+    console.warn(`Skip parsing defaults for ${svelteFile}`);
+    return result;
+  }
+
+  const ast = parse(content, { modern: true });
+
+  const script = ast.instance;
+
+  if (!script) {
+    return result;
+  }
+
+  const { body } = script.content;
+
+  for (const node of body) {
+    if (node.type !== "VariableDeclaration" || node.declarations.length !== 1) {
+      continue;
+    }
+
+    const [{ id, init }] = node.declarations;
+
+    if (
+      init?.type !== "CallExpression" ||
+      init.callee.type !== "Identifier" ||
+      init.callee.name !== "$props" ||
+      id.type !== "ObjectPattern"
+    ) {
+      continue;
+    }
+
+    for (const prop of id.properties) {
+      if (prop.type !== "Property") {
+        continue;
+      }
+
+      const { key, value } = prop;
+
+      if (key.type !== "Identifier") {
+        continue;
+      }
+
+      const { name } = key;
+
+      if (value.type === "Identifier" && value.name === name) {
+        // Case: const { name } = $props(); => The prop has no default
+        result.set(name, {});
+      }
+
+      if (value.type === "AssignmentPattern") {
+        // Case: const { name = "default" } = $props(); => The prop has a default value
+        const { right } = value;
+
+        if (right.type === "Literal") {
+          result.set(name, { default: right.raw });
+        } else if (
+          right.type === "CallExpression" &&
+          right.callee.type === "Identifier" &&
+          right.callee.name === "$bindable"
+        ) {
+          const [arg] = right.arguments;
+
+          // @ts-expect-error Svelte parser doesn't add start/end to types for some reason
+          const txt = arg ? content.slice(arg.start, arg.end) || "unknown" : "undefined";
+
+          result.set(name, { bindable: true, default: txt });
+        }
+      }
+    }
+  }
+
+  return result;
+}

--- a/docgen/props/parsePropsInterface/defs.ts
+++ b/docgen/props/parsePropsInterface/defs.ts
@@ -91,6 +91,19 @@ export interface ParsedInterface {
   typeDependencies: Record<string, ParsedType | ParsedType[]>;
 }
 
+/**
+ * Information about a property's default value and bindable status.
+ *
+ * This info is derived from the component's Svelte file directly, and used to enrich the `ParsedProperty` type.
+ */
+export type ParsedDefaults = Map<
+  string,
+  {
+    default?: string;
+    bindable?: boolean;
+  }
+>;
+
 /** Type names whose resolved union values should never be inlined. */
 export const PRESERVE_TYPE_NAMES = new Set(["Snippet", "MaterialSymbol"]);
 

--- a/docgen/props/parsePropsInterface/extractor.ts
+++ b/docgen/props/parsePropsInterface/extractor.ts
@@ -101,7 +101,9 @@ export async function extractDomConstraint(
  * (non-DOM, non-external) interfaces, recursively. This "flattens" the modular interface hierarchy
  * and substitutes generic parameter types with their actual type arguments.
  */
-export function extractExtendedInternalProperties(interfaceDecl: InterfaceDeclaration): ExtendedProperty[] {
+export function extractExtendedInternalProperties(
+  interfaceDecl: InterfaceDeclaration
+): ExtendedProperty[] {
   const properties: ExtendedProperty[] = [];
   const extendsClauses = interfaceDecl.getExtends();
 
@@ -116,7 +118,7 @@ export function extractExtendedInternalProperties(interfaceDecl: InterfaceDeclar
     // Resolve the type of this extends clause
     const exprType = clause.getType();
     const symbol = exprType.getSymbol();
-    
+
     const paramMap = new Map<string, string>();
     if (symbol) {
       const decl = symbol.getDeclarations()[0];
@@ -187,29 +189,6 @@ export function extractDescription(decl: Node) {
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
-}
-
-/** Extracts the `@default` tag value from a property's JSDoc, if present. */
-export function extractDefaultValue(decl: Node) {
-  if (!Node.isJSDocable(decl)) {
-    return;
-  }
-
-  const jsDocs = decl.getJsDocs();
-  if (jsDocs.length === 0) {
-    return;
-  }
-
-  const doc = jsDocs[0];
-  const tags = doc.getTags();
-  const defaultTag = tags.find((tag) => tag.getTagName() === "default");
-
-  if (!defaultTag) {
-    return;
-  }
-
-  const commentText = defaultTag.getCommentText();
-  return commentText?.trim();
 }
 
 /**

--- a/docgen/props/parsePropsInterface/extractor.ts
+++ b/docgen/props/parsePropsInterface/extractor.ts
@@ -1,7 +1,13 @@
 import { Node, TypeFormatFlags } from "ts-morph";
 import { type ParsedGeneric, type ParsedType, TypeSrcMap } from "./defs";
 import { parseType } from "./parser";
-import type { Project, InterfaceDeclaration, Type } from "ts-morph";
+import type { Project, InterfaceDeclaration, Type, Symbol as MorphSymbol } from "ts-morph";
+
+export interface ExtendedProperty {
+  symbol: MorphSymbol;
+  decl?: Node;
+  rawAnnotation?: string;
+}
 
 /**
  * Finds all exported interface declarations that end with `Props` in a source file.
@@ -91,11 +97,12 @@ export async function extractDomConstraint(
 }
 
 /**
- * Collects property symbols from all extended internal (non-DOM, non-external)
- * interfaces, recursively. This "flattens" the modular interface hierarchy.
+ * Collects property symbols and their declaration details from all extended internal
+ * (non-DOM, non-external) interfaces, recursively. This "flattens" the modular interface hierarchy
+ * and substitutes generic parameter types with their actual type arguments.
  */
-export function extractExtendedInternalProperties(interfaceDecl: InterfaceDeclaration) {
-  const properties = [];
+export function extractExtendedInternalProperties(interfaceDecl: InterfaceDeclaration): ExtendedProperty[] {
+  const properties: ExtendedProperty[] = [];
   const extendsClauses = interfaceDecl.getExtends();
 
   for (const clause of extendsClauses) {
@@ -108,9 +115,53 @@ export function extractExtendedInternalProperties(interfaceDecl: InterfaceDeclar
 
     // Resolve the type of this extends clause
     const exprType = clause.getType();
+    const symbol = exprType.getSymbol();
+    
+    const paramMap = new Map<string, string>();
+    if (symbol) {
+      const decl = symbol.getDeclarations()[0];
+      if (decl && Node.isInterfaceDeclaration(decl)) {
+        const typeParams = decl.getTypeParameters();
+        const typeArgs = clause.getTypeArguments();
+        for (let i = 0; i < typeParams.length; i++) {
+          const param = typeParams[i];
+          const arg = typeArgs[i];
+          const paramName = param.getName();
+          if (arg) {
+            paramMap.set(paramName, arg.getText());
+          } else {
+            const defaultType = param.getDefault();
+            if (defaultType) {
+              paramMap.set(paramName, defaultType.getText());
+            }
+          }
+        }
+      }
+    }
 
     for (const prop of exprType.getProperties()) {
-      properties.push(prop);
+      const decls = prop.getDeclarations();
+      const propDecl = decls[0];
+      let rawAnnotation: string | undefined;
+
+      if (propDecl && Node.isPropertySignature(propDecl)) {
+        const typeNode = propDecl.getTypeNode();
+        if (typeNode) {
+          rawAnnotation = typeNode.getText({ includeJsDocComments: false });
+          if (paramMap.size > 0) {
+            for (const [paramName, argText] of paramMap.entries()) {
+              const regex = new RegExp(`\\b${paramName}\\b`, "g");
+              rawAnnotation = rawAnnotation.replace(regex, argText);
+            }
+          }
+        }
+      }
+
+      properties.push({
+        symbol: prop,
+        decl: propDecl,
+        rawAnnotation,
+      });
     }
   }
 

--- a/docgen/props/parsePropsInterface/index.ts
+++ b/docgen/props/parsePropsInterface/index.ts
@@ -3,6 +3,8 @@ import { Project } from "ts-morph";
 
 import { extractInterfaces } from "./extractor";
 import { parseInterface } from "./parser";
+import { parseDefaults } from "./defaults";
+import { ParsedPropertyFlags } from "./defs";
 
 const tsConfigFilePath = path.join(__dirname, "../../../tsconfig.json");
 
@@ -21,6 +23,26 @@ export async function parseInterfaces(filePath: string) {
   const interfaces = extractInterfaces(cachedProject, filePath);
 
   const parsed = await Promise.all(interfaces.map(parseInterface));
+
+  for (const [name, parsedInterface] of parsed) {
+    const svelteFile = path.join(path.dirname(filePath), name.replace("Props", ".svelte"));
+
+    const parsedDefaults = await parseDefaults(svelteFile);
+
+    for (const prop of parsedInterface.properties) {
+      const p = parsedDefaults.get(prop.name);
+
+      if (!p) {
+        prop.default = "undefined";
+        continue;
+      }
+
+      prop.default = p.default ?? "undefined";
+      if (p.bindable) {
+        prop.flags |= ParsedPropertyFlags.BINDABLE;
+      }
+    }
+  }
 
   return Object.fromEntries(parsed);
 }

--- a/docgen/props/parsePropsInterface/parser.ts
+++ b/docgen/props/parsePropsInterface/parser.ts
@@ -9,7 +9,6 @@ import {
   PRESERVE_TYPE_NAMES,
 } from "./defs";
 import {
-  extractDefaultValue,
   extractDescription,
   extractDomConstraint,
   extractExtendedInternalProperties,
@@ -17,12 +16,7 @@ import {
   extractInternalTypeReferenceSymbol,
   extractTypeSrc,
 } from "./extractor";
-import {
-  isImportedFromExternal,
-  isPropertyBindable,
-  isPropertyOptional,
-  isTypeAlias,
-} from "./checker";
+import { isImportedFromExternal, isPropertyOptional, isTypeAlias } from "./checker";
 import { resolvePropertyType } from "./resolver";
 import { removeChildrenComments, splitUnionParts } from "./utils";
 
@@ -250,21 +244,15 @@ async function parseProperty(
 
   let description = "";
   let optionalFlag = ParsedPropertyFlags.NONE;
-  let defaultValue;
-  let bindableFlag = ParsedPropertyFlags.NONE;
 
   const declarations = prop.getDeclarations();
   const decl = customDecl ?? declarations.at(0);
 
   if (decl) {
     description = extractDescription(decl);
-    defaultValue = extractDefaultValue(decl);
 
     if (isPropertyOptional(decl)) {
       optionalFlag = ParsedPropertyFlags.OPTIONAL;
-    }
-    if (isPropertyBindable(decl)) {
-      bindableFlag = ParsedPropertyFlags.BINDABLE;
     }
   }
 
@@ -280,11 +268,12 @@ async function parseProperty(
   const result: ParsedProperty = {
     name,
     description,
-    flags: flags | optionalFlag | bindableFlag,
+    flags: flags | optionalFlag, // Bindable flag is handled later by the parseDefaults function
     type,
   };
 
-  result.default = defaultValue ?? "undefined";
+  // Default values are handled later by the parseDefaults function
+  result.default = "undefined";
 
   return result;
 }

--- a/docgen/props/parsePropsInterface/parser.ts
+++ b/docgen/props/parsePropsInterface/parser.ts
@@ -47,8 +47,15 @@ export async function parseInterface(
 
   // 1. Collect properties from extended internal interfaces
   const extendedProps = extractExtendedInternalProperties(interfaceDecl);
-  for (const prop of extendedProps) {
-    const parsed = await parseProperty(prop, interfaceDecl, genericNames, typeDependencies);
+  for (const extProp of extendedProps) {
+    const parsed = await parseProperty(
+      extProp.symbol,
+      interfaceDecl,
+      genericNames,
+      typeDependencies,
+      extProp.decl,
+      extProp.rawAnnotation
+    );
     propertyMap.set(parsed.name, parsed);
   }
 
@@ -235,7 +242,9 @@ async function parseProperty(
   prop: MorphSymbol,
   contextNode: Node,
   genericNames: Set<string>,
-  typeDependencies: Record<string, ParsedType | ParsedType[]>
+  typeDependencies: Record<string, ParsedType | ParsedType[]>,
+  customDecl?: Node,
+  customRawAnnotation?: string
 ) {
   const name = prop.getName();
 
@@ -245,7 +254,7 @@ async function parseProperty(
   let bindableFlag = ParsedPropertyFlags.NONE;
 
   const declarations = prop.getDeclarations();
-  const decl = declarations.at(0);
+  const decl = customDecl ?? declarations.at(0);
 
   if (decl) {
     description = extractDescription(decl);
@@ -264,7 +273,8 @@ async function parseProperty(
     decl,
     contextNode,
     genericNames,
-    typeDependencies
+    typeDependencies,
+    customRawAnnotation
   );
 
   const result: ParsedProperty = {

--- a/docgen/props/parsePropsInterface/resolver.ts
+++ b/docgen/props/parsePropsInterface/resolver.ts
@@ -18,11 +18,13 @@ export async function resolvePropertyType(
   decl: Node | undefined,
   contextNode: Node,
   genericNames: Set<string>,
-  typeDependencies: Record<string, ParsedType | ParsedType[]>
+  typeDependencies: Record<string, ParsedType | ParsedType[]>,
+  customRawAnnotation?: string
 ) {
   const propType = prop.getTypeAtLocation(contextNode);
   const nonNullType = propType.getNonNullableType();
-  const rawAnnotation = extractRawTypeAnnotation(decl);
+  const rawAnnotation = customRawAnnotation ?? extractRawTypeAnnotation(decl);
+  const checkNode = decl ?? contextNode;
 
   if (nonNullType.isArray()) {
     const elementType = nonNullType.getArrayElementTypeOrThrow();
@@ -45,7 +47,7 @@ export async function resolvePropertyType(
     if (elementRawAnnotation) {
       const utilityType = await tryResolveUtilityTypes(
         elementRawAnnotation,
-        contextNode,
+        checkNode,
         typeDependencies
       );
       if (utilityType) {
@@ -57,7 +59,7 @@ export async function resolvePropertyType(
 
       const preserved = await tryPreserveAnnotation(
         elementRawAnnotation,
-        contextNode,
+        checkNode,
         typeDependencies
       );
 
@@ -74,7 +76,7 @@ export async function resolvePropertyType(
       const res = await resolveAliasedType(
         elementType,
         elementAliasSymbol,
-        contextNode,
+        checkNode,
         elementRawAnnotation,
         typeDependencies,
         decl
@@ -88,7 +90,7 @@ export async function resolvePropertyType(
     if (elementType.isUnion()) {
       const res = await resolveUnionType(
         elementType,
-        contextNode,
+        checkNode,
         genericNames,
         elementRawAnnotation,
         typeDependencies,
@@ -100,9 +102,9 @@ export async function resolvePropertyType(
       };
     }
 
-    const elementText = extractTypeText(elementType, contextNode);
+    const elementText = extractTypeText(elementType, checkNode);
     return {
-      type: await parseType(elementRawAnnotation ?? elementText, typeDependencies, contextNode),
+      type: await parseType(elementRawAnnotation ?? elementText, typeDependencies, checkNode),
       flags: ParsedPropertyFlags.ARRAY,
     };
   }
@@ -111,30 +113,30 @@ export async function resolvePropertyType(
   if (rawAnnotation && rawAnnotation.startsWith("Snippet")) {
     const params = resolveSnippetParams(rawAnnotation);
     return {
-      type: await parseType(params ?? "void", typeDependencies, contextNode),
+      type: await parseType(params ?? "void", typeDependencies, checkNode),
       flags: ParsedPropertyFlags.SNIPPET,
     };
   }
 
   // Check if it's a Snippet from a resolved type (e.g. when inherited)
   const aliasSymbol = propType.getAliasSymbol();
-  const resolvedText = extractTypeText(nonNullType, contextNode);
+  const resolvedText = extractTypeText(nonNullType, checkNode);
 
   if (aliasSymbol?.getName() === "Snippet" || resolvedText.startsWith("Snippet")) {
     const fullText = aliasSymbol
-      ? nonNullType.getText(contextNode, TypeFormatFlags.NoTruncation)
+      ? nonNullType.getText(checkNode, TypeFormatFlags.NoTruncation)
       : resolvedText;
     const params = resolveSnippetParams(fullText);
 
     return {
-      type: await parseType(params ?? "void", typeDependencies, contextNode),
+      type: await parseType(params ?? "void", typeDependencies, checkNode),
       flags: ParsedPropertyFlags.SNIPPET,
     };
   }
 
   // Check if the raw annotation references a preserved or external type
   if (rawAnnotation) {
-    const utilityType = await tryResolveUtilityTypes(rawAnnotation, contextNode, typeDependencies);
+    const utilityType = await tryResolveUtilityTypes(rawAnnotation, checkNode, typeDependencies);
 
     if (utilityType) {
       return {
@@ -143,7 +145,7 @@ export async function resolvePropertyType(
       };
     }
 
-    const preserved = await tryPreserveAnnotation(rawAnnotation, contextNode, typeDependencies);
+    const preserved = await tryPreserveAnnotation(rawAnnotation, checkNode, typeDependencies);
 
     if (preserved) {
       return {
@@ -161,7 +163,7 @@ export async function resolvePropertyType(
       nonNullType.getUnionTypes().every((union) => union.isBooleanLiteral()))
   ) {
     return {
-      type: await parseType("boolean", typeDependencies, contextNode),
+      type: await parseType("boolean", typeDependencies, checkNode),
       flags: ParsedPropertyFlags.NONE,
     };
   }
@@ -171,7 +173,7 @@ export async function resolvePropertyType(
     return {
       type: await resolveUnionType(
         nonNullType,
-        contextNode,
+        checkNode,
         genericNames,
         rawAnnotation,
         typeDependencies,
@@ -184,7 +186,7 @@ export async function resolvePropertyType(
   // Handle `keyof X` types and types that use a generic parameter
   if (rawAnnotation && (rawAnnotation.startsWith("keyof ") || genericNames.has(rawAnnotation))) {
     return {
-      type: await parseType(rawAnnotation, typeDependencies, contextNode),
+      type: await parseType(rawAnnotation, typeDependencies, checkNode),
       flags: ParsedPropertyFlags.NONE,
     };
   }
@@ -195,7 +197,7 @@ export async function resolvePropertyType(
       type: await resolveAliasedType(
         nonNullType,
         aliasSymbol,
-        contextNode,
+        checkNode,
         rawAnnotation,
         typeDependencies,
         decl
@@ -206,7 +208,7 @@ export async function resolvePropertyType(
 
   // Default: use the resolved type text
   return {
-    type: await parseType(resolvedText, typeDependencies, contextNode),
+    type: await parseType(resolvedText, typeDependencies, checkNode),
     flags: ParsedPropertyFlags.NONE,
   };
 }
@@ -347,14 +349,24 @@ async function tryResolveUtilityTypes(
     return undefined;
   }
 
+  const collapse = (parsed: ParsedType | ParsedType[]): ParsedType => {
+    if (!Array.isArray(parsed)) {
+      return parsed;
+    }
+    const parts = parsed.map((p) => ("name" in p ? p.name : p.definition));
+    return {
+      definition: parts.join(" | "),
+    };
+  };
+
   const omitMatch = rawAnnotation.match(/^Omit\s*<\s*(.+?)\s*,\s*(.+?)\s*>$/s);
   if (omitMatch) {
     const targetType = omitMatch[1].trim();
     const keys = omitMatch[2].trim();
-    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
-    const parsedKeys = await parseType(keys, typeDependencies, contextNode);
+    const parsedTarget = collapse(await parseType(targetType, typeDependencies, contextNode));
+    const parsedKeys = collapse(await parseType(keys, typeDependencies, contextNode));
     return {
-      type: [parsedTarget as ParsedType, parsedKeys as ParsedType],
+      type: [parsedTarget, parsedKeys],
       flag: ParsedPropertyFlags.OMIT,
     };
   }
@@ -363,10 +375,10 @@ async function tryResolveUtilityTypes(
   if (excludeMatch) {
     const targetType = excludeMatch[1].trim();
     const excluded = excludeMatch[2].trim();
-    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
-    const parsedExcluded = await parseType(excluded, typeDependencies, contextNode);
+    const parsedTarget = collapse(await parseType(targetType, typeDependencies, contextNode));
+    const parsedExcluded = collapse(await parseType(excluded, typeDependencies, contextNode));
     return {
-      type: [parsedTarget as ParsedType, parsedExcluded as ParsedType],
+      type: [parsedTarget, parsedExcluded],
       flag: ParsedPropertyFlags.EXCLUDE,
     };
   }
@@ -375,10 +387,10 @@ async function tryResolveUtilityTypes(
   if (pickMatch) {
     const targetType = pickMatch[1].trim();
     const keys = pickMatch[2].trim();
-    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
-    const parsedKeys = await parseType(keys, typeDependencies, contextNode);
+    const parsedTarget = collapse(await parseType(targetType, typeDependencies, contextNode));
+    const parsedKeys = collapse(await parseType(keys, typeDependencies, contextNode));
     return {
-      type: [parsedTarget as ParsedType, parsedKeys as ParsedType],
+      type: [parsedTarget, parsedKeys],
       flag: ParsedPropertyFlags.PICK,
     };
   }
@@ -387,10 +399,10 @@ async function tryResolveUtilityTypes(
   if (extractMatch) {
     const targetType = extractMatch[1].trim();
     const extracted = extractMatch[2].trim();
-    const parsedTarget = await parseType(targetType, typeDependencies, contextNode);
-    const parsedExtracted = await parseType(extracted, typeDependencies, contextNode);
+    const parsedTarget = collapse(await parseType(targetType, typeDependencies, contextNode));
+    const parsedExtracted = collapse(await parseType(extracted, typeDependencies, contextNode));
     return {
-      type: [parsedTarget as ParsedType, parsedExtracted as ParsedType],
+      type: [parsedTarget, parsedExtracted],
       flag: ParsedPropertyFlags.EXTRACT,
     };
   }


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Fix type parsing for `extends` types so they appear like others (useful for later when sharing props)
- Parse the default values and `$bindable` state of props from svelte files directly. This avoid having to type `@default` and `@bindable` every time in `props.ts` (and avoids type sync issues)

> For later: the second point might make us need to rerun docgen manually each time we change  default values in svelte files or need a Vite plugin to do it manually

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
