### PR TITLE
refactor: remove unused JSDoc, share props with centralized interface…

### DIFF
--- a/docgen/props/parsePropsInterface/defaults.ts
+++ b/docgen/props/parsePropsInterface/defaults.ts
@@ -58,22 +58,31 @@ export async function parseDefaults(svelteFile: string) {
       }
 
       if (value.type === "AssignmentPattern") {
-        // Case: const { name = "default" } = $props(); => The prop has a default value
+        // Case: const { name = ... } = $props(); => The prop has a default value
         const { right } = value;
 
         if (right.type === "Literal") {
+          // Case: const { name = "default" } = $props();
           result.set(name, { default: right.raw });
         } else if (
           right.type === "CallExpression" &&
           right.callee.type === "Identifier" &&
           right.callee.name === "$bindable"
         ) {
+          // Case: const { name = $bindable(...) } = $props();
           const [arg] = right.arguments;
 
           // @ts-expect-error Svelte parser doesn't add start/end to types for some reason
           const txt = arg ? content.slice(arg.start, arg.end) || "unknown" : "undefined";
 
           result.set(name, { bindable: true, default: txt });
+        } else {
+          // Case: const { name = ... } = $props(); where ... is neither a Literal nor a "$bindable" CallExpression
+
+          // @ts-expect-error Svelte parser doesn't add start/end to types for some reason
+          const txt = content.slice(right.start, right.end) || "unknown";
+
+          result.set(name, { default: txt });
         }
       }
     }

--- a/docgen/props/parsePropsInterface/extractor.ts
+++ b/docgen/props/parsePropsInterface/extractor.ts
@@ -7,6 +7,7 @@ export interface ExtendedProperty {
   symbol: MorphSymbol;
   decl?: Node;
   rawAnnotation?: string;
+  defaultValue?: string;
 }
 
 /**
@@ -129,6 +130,7 @@ export function extractExtendedInternalProperties(
           const param = typeParams[i];
           const arg = typeArgs[i];
           const paramName = param.getName();
+
           if (arg) {
             paramMap.set(paramName, arg.getText());
           } else {
@@ -142,11 +144,15 @@ export function extractExtendedInternalProperties(
     }
 
     for (const prop of exprType.getProperties()) {
+      let defaultValue: string | undefined;
       const decls = prop.getDeclarations();
       const propDecl = decls[0];
+
       let rawAnnotation: string | undefined;
 
       if (propDecl && Node.isPropertySignature(propDecl)) {
+        defaultValue = extractDefaultValue(propDecl);
+
         const typeNode = propDecl.getTypeNode();
         if (typeNode) {
           rawAnnotation = typeNode.getText({ includeJsDocComments: false });
@@ -160,6 +166,7 @@ export function extractExtendedInternalProperties(
       }
 
       properties.push({
+        defaultValue,
         symbol: prop,
         decl: propDecl,
         rawAnnotation,
@@ -189,6 +196,29 @@ export function extractDescription(decl: Node) {
     .map((line) => line.trim())
     .filter(Boolean)
     .join("\n");
+}
+
+/** Extracts the `@default` tag value from a property's JSDoc, if present. */
+export function extractDefaultValue(decl: Node) {
+  if (!Node.isJSDocable(decl)) {
+    return;
+  }
+
+  const jsDocs = decl.getJsDocs();
+  if (jsDocs.length === 0) {
+    return;
+  }
+
+  const doc = jsDocs[0];
+  const tags = doc.getTags();
+  const defaultTag = tags.find((tag) => tag.getTagName() === "default");
+
+  if (!defaultTag) {
+    return;
+  }
+
+  const commentText = defaultTag.getCommentText();
+  return commentText?.trim();
 }
 
 /**

--- a/docgen/props/parsePropsInterface/index.ts
+++ b/docgen/props/parsePropsInterface/index.ts
@@ -33,7 +33,7 @@ export async function parseInterfaces(filePath: string) {
       const p = parsedDefaults.get(prop.name);
 
       if (!p) {
-        prop.default = "undefined";
+        prop.default = prop.default ?? "undefined";
         continue;
       }
 

--- a/docgen/props/parsePropsInterface/parser.ts
+++ b/docgen/props/parsePropsInterface/parser.ts
@@ -41,6 +41,7 @@ export async function parseInterface(
 
   // 1. Collect properties from extended internal interfaces
   const extendedProps = extractExtendedInternalProperties(interfaceDecl);
+
   for (const extProp of extendedProps) {
     const parsed = await parseProperty(
       extProp.symbol,
@@ -50,6 +51,8 @@ export async function parseInterface(
       extProp.decl,
       extProp.rawAnnotation
     );
+
+    parsed.default = extProp.defaultValue;
     propertyMap.set(parsed.name, parsed);
   }
 
@@ -271,9 +274,6 @@ async function parseProperty(
     flags: flags | optionalFlag, // Bindable flag is handled later by the parseDefaults function
     type,
   };
-
-  // Default values are handled later by the parseDefaults function
-  result.default = "undefined";
 
   return result;
 }

--- a/docgen/props/parsePropsInterface/parser.ts
+++ b/docgen/props/parsePropsInterface/parser.ts
@@ -18,7 +18,7 @@ import {
 } from "./extractor";
 import { isImportedFromExternal, isPropertyOptional, isTypeAlias } from "./checker";
 import { resolvePropertyType } from "./resolver";
-import { removeChildrenComments, splitUnionParts } from "./utils";
+import { removeChildrenComments, simplifyExcludeUndefined, splitUnionParts } from "./utils";
 
 /**
  * Parses a full interface declaration into a `ParsedInterface`.
@@ -92,6 +92,7 @@ export async function parseType(
   visited: Set<string> = new Set(),
   resolvedSymbol?: MorphSymbol
 ): Promise<ParsedType | ParsedType[]> {
+  typeText = simplifyExcludeUndefined(typeText);
   const parts = splitUnionParts(typeText);
 
   if (parts.length > 1) {

--- a/docgen/props/parsePropsInterface/resolver.ts
+++ b/docgen/props/parsePropsInterface/resolver.ts
@@ -8,7 +8,7 @@ import {
 } from "./defs";
 import { extractRawTypeAnnotation, extractTypeText } from "./extractor";
 import { parseType } from "./parser";
-import { tryPreserveAnnotation, splitUnionParts } from "./utils";
+import { tryPreserveAnnotation, simplifyExcludeUndefined, splitUnionParts } from "./utils";
 
 /**
  * Core type resolution logic. Determines how to represent a property's type.
@@ -23,7 +23,10 @@ export async function resolvePropertyType(
 ) {
   const propType = prop.getTypeAtLocation(contextNode);
   const nonNullType = propType.getNonNullableType();
-  const rawAnnotation = customRawAnnotation ?? extractRawTypeAnnotation(decl);
+  let rawAnnotation = customRawAnnotation ?? extractRawTypeAnnotation(decl);
+  if (rawAnnotation) {
+    rawAnnotation = simplifyExcludeUndefined(rawAnnotation);
+  }
   const checkNode = decl ?? contextNode;
 
   if (nonNullType.isArray()) {

--- a/docgen/props/parsePropsInterface/utils.ts
+++ b/docgen/props/parsePropsInterface/utils.ts
@@ -113,3 +113,58 @@ export function removeChildrenComments(node: Node) {
     }
   });
 }
+
+/**
+ * Simplifies occurrences of `Exclude<T, undefined>` inside type text to `T`.
+ */
+export function simplifyExcludeUndefined(text: string): string {
+  let result = "";
+  let i = 0;
+
+  while (i < text.length) {
+    const isWordStart = i === 0 || !/[a-zA-Z0-9_$]/.test(text[i - 1]);
+    if (isWordStart && text.startsWith("Exclude<", i)) {
+      let depth = 0;
+      let commaIdx = -1;
+      let endIdx = -1;
+      const startIdx = i + "Exclude<".length;
+
+      for (let j = startIdx; j < text.length; j++) {
+        const char = text[j];
+        if (char === "<") {
+          depth++;
+        } else if (char === ">") {
+          if (depth === 0) {
+            endIdx = j;
+            break;
+          }
+          depth--;
+        } else if (char === "," && depth === 0) {
+          commaIdx = j;
+        }
+      }
+
+      if (commaIdx !== -1 && endIdx !== -1) {
+        // Exclude<T, U> where tVal is T and uVal is U
+        const tVal = text.substring(startIdx, commaIdx).trim();
+        const uVal = text.substring(commaIdx + 1, endIdx).trim();
+
+        const simplifiedT = simplifyExcludeUndefined(tVal);
+        const simplifiedU = simplifyExcludeUndefined(uVal);
+
+        if (simplifiedU === "undefined") {
+          result += simplifiedT;
+        } else {
+          result += `Exclude<${simplifiedT}, ${simplifiedU}>`;
+        }
+        i = endIdx + 1;
+        continue;
+      }
+    }
+
+    result += text[i];
+    i++;
+  }
+
+  return result;
+}

--- a/src/lib/components/avatar/props.ts
+++ b/src/lib/components/avatar/props.ts
@@ -1,4 +1,4 @@
-import type { CssValue, QSize } from "$utils";
+import type { Sizeable } from "$utils";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 
@@ -13,8 +13,6 @@ export type QAvatarShapeOptions =
   | "top-right-round"
   | "bottom-left-round"
   | "bottom-right-round";
-
-export type QAvatarSizeOptions = QSize | CssValue | number;
 
 export type VideoTypes =
   | "video/mp4"
@@ -37,43 +35,30 @@ export type QAvatarVideoSrcOptions = {
   type: VideoTypes;
 };
 
-export interface QAvatarProps extends HTMLAttributes<HTMLElement> {
+export interface QAvatarProps extends Sizeable, HTMLAttributes<HTMLElement> {
   /**
    * Shape of the avatar.
-   *
-   * @default "circle"
    */
   shape?: QAvatarShapeOptions;
-  /**
-   * Size of the avatar, can be a custom size using CSS units. If no unit is specified, "px" will be used.
-   *
-   * @default "md"
-   */
-  size?: QAvatarSizeOptions;
   /**
    * Source of the image to be used as the avatar. Can be a url or a path to a local file.
    *
    * If the "video" prop is set to true, this will be used as an MP4 video source. If you want to use a different video format, use the "sources" prop.
-   *
    */
   src?: string;
   /**
    * Only for video avatars. Use this prop to specify multiple sources for the video. The browser will play the first source it can support. This overrides the "src" prop.
    *
    * If used while the "video" prop is set to false, this prop has no effect.
-   *
    */
   sources?: QAvatarVideoSrcOptions[];
   /**
    * If set to true, the avatar will be treaded as a video avatar.
    * This means that the "src" prop will be used as an MP4 video source and the "sources" prop can be used to specify multiple sources for the video.
-   *
-   * @default false
    */
   video?: boolean;
   /**
    * alt property for the image.
-   *
    */
   alt?: string;
   /**
@@ -82,7 +67,6 @@ export interface QAvatarProps extends HTMLAttributes<HTMLElement> {
    * This can also be use to add captions or subtitles to the video or even to add the sources manually (without using the "src" or "sources" props).
    *
    * This snippet will be added inside the <video> tag.
-   *
    */
   videoAccessibility?: Snippet;
 }

--- a/src/lib/components/breadcrumbs/QBreadcrumbs.svelte
+++ b/src/lib/components/breadcrumbs/QBreadcrumbs.svelte
@@ -5,6 +5,8 @@
   export const breadcrumbsCtx = QContext<{
     readonly separator: QBreadcrumbsProps["separator"];
     readonly gutter: QBreadcrumbsProps["gutter"];
+    readonly activeClass: QBreadcrumbsProps["activeClass"];
+    readonly activeStyle: QBreadcrumbsProps["activeStyle"];
   }>("QBreadcrumbs");
 </script>
 
@@ -33,7 +35,12 @@
   // #endregion: --- Non-reactive variables
 
   // #region:    --- Context
-  breadcrumbsCtx.set({ separator, gutter });
+  breadcrumbsCtx.set({
+    separator,
+    gutter,
+    activeClass: props.activeClass,
+    activeStyle: props.activeStyle,
+  });
   // #endregion: --- Context
 
   // #region:    --- Lifecycle

--- a/src/lib/components/breadcrumbs/QBreadcrumbsEl.scss
+++ b/src/lib/components/breadcrumbs/QBreadcrumbsEl.scss
@@ -15,6 +15,10 @@
     }
   }
 
+  &:first-child > .q-breadcrumbs__separator {
+    display: none;
+  }
+
   .q-breadcrumbs__separator {
     color: var(--q-separator-color, currentColor);
   }

--- a/src/lib/components/breadcrumbs/QBreadcrumbsEl.svelte
+++ b/src/lib/components/breadcrumbs/QBreadcrumbsEl.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-  import { isRouteActive } from "$utils";
+  import { getRouterInfo } from "$utils";
   import QIcon from "$components/icon/QIcon.svelte";
   import { breadcrumbsCtx } from "./QBreadcrumbs.svelte";
   import type { MaterialSymbol } from "material-symbols";
@@ -7,30 +7,39 @@
 
   // #region:    --- Props
   let {
-    activeClass = "active",
-    href,
     label = "",
     icon,
     tag = "span",
-    to,
     children = fallback,
     ...props
   }: QBreadcrumbsElProps = $props();
   // #endregion: --- Props
 
-  // #region:    --- Derived values
-  const isActive = $derived(isRouteActive(href || to));
-  // #endregion: --- Derived values
-
   // #region:    --- Context
   const ctx = breadcrumbsCtx.assertGet();
   // #endregion: --- Context
 
+  // #region:    --- Derived values
+  const routerInfo = $derived(getRouterInfo(props));
+  const activeClass = $derived(props.activeClass ?? ctx.activeClass);
+  const style = $derived(
+    [
+      routerInfo.isActive && (props.activeStyle ?? ctx.activeStyle),
+      routerInfo.isActive && "--q-breadcrumbs-color: var(--q-active-color)",
+      props.style,
+    ]
+      .filter(Boolean)
+      .join("; ")
+  );
+  // #endregion: --- Derived values
+
   Q.classes("q-breadcrumbs__item", { classes: [props.class] });
   Q.classes("q-breadcrumbs__separator", {
-    classes: [`q-px-${ctx?.gutter}`],
+    classes: [`q-px-${ctx.gutter}`],
   });
-  Q.classes("q-breadcrumbs__el", { classes: [isActive && activeClass] });
+  Q.classes("q-breadcrumbs__el", {
+    classes: [routerInfo.linkClass, routerInfo.isActive && activeClass],
+  });
 </script>
 
 {#snippet fallback()}
@@ -53,11 +62,7 @@
   </span>
 {/snippet}
 
-<li
-  {...props}
-  class="q-breadcrumbs__item"
-  style:--q-breadcrumbs-color={isActive ? "var(--q-active-color)" : undefined}
->
+<li {...props} class="q-breadcrumbs__item" {style}>
   <span class="q-breadcrumbs__separator" aria-hidden="true">
     {#if typeof ctx.separator === "string"}
       {#if ctx.separator.startsWith("icon:")}
@@ -70,11 +75,11 @@
     {/if}
   </span>
 
-  {#if href || to}
+  {#if routerInfo.hasLink}
     <a
-      href={href || to}
+      {...routerInfo.linkAttributes}
       class="q-breadcrumbs__el"
-      aria-current={isActive ? "page" : undefined}
+      aria-current={routerInfo.isActive ? "page" : undefined}
       data-quaff
     >
       {@render breadcrumbEl()}

--- a/src/lib/components/breadcrumbs/docs.ts
+++ b/src/lib/components/breadcrumbs/docs.ts
@@ -5,6 +5,11 @@ import {
   QBreadcrumbsDocsGenerics,
   QBreadcrumbsDocsDomAttributesConstraint,
   QBreadcrumbsDocsTypeDependencies,
+  QBreadcrumbsElDocsProps,
+  QBreadcrumbsElDocsSnippets,
+  QBreadcrumbsElDocsGenerics,
+  QBreadcrumbsElDocsDomAttributesConstraint,
+  QBreadcrumbsElDocsTypeDependencies,
 } from "./docs.props";
 
 export const QBreadcrumbsDocs: QComponentDocs = {
@@ -19,5 +24,19 @@ export const QBreadcrumbsDocs: QComponentDocs = {
     methods: [],
     events: [],
     typeDependencies: QBreadcrumbsDocsTypeDependencies,
+  },
+};
+
+export const QBreadcrumbsElDocs: QComponentDocs = {
+  name: "QBreadcrumbsEl",
+  description: "A single breadcrumb element to be used within a QBreadcrumbs container.",
+  docs: {
+    generics: QBreadcrumbsElDocsGenerics,
+    domAttributesConstraint: QBreadcrumbsElDocsDomAttributesConstraint,
+    props: QBreadcrumbsElDocsProps,
+    snippets: QBreadcrumbsElDocsSnippets,
+    methods: [],
+    events: [],
+    typeDependencies: QBreadcrumbsElDocsTypeDependencies,
   },
 };

--- a/src/lib/components/breadcrumbs/props.ts
+++ b/src/lib/components/breadcrumbs/props.ts
@@ -1,59 +1,37 @@
-import type { QSize, StringWithSuggestions } from "$utils";
+import type { Labelable, Linkable, QSize, StringWithSuggestions, WithActiveAttrs } from "$utils";
 import type { MaterialSymbol } from "material-symbols";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 
 export type QBreadcrumbsGutterOptions = Exclude<QSize, "xs" | "xl">;
 
-export interface QBreadcrumbsProps extends HTMLAttributes<HTMLElement> {
+export interface QBreadcrumbsProps extends WithActiveAttrs, HTMLAttributes<HTMLElement> {
   /**
    * Color to use for the active breadcrumb element. See <link to colors docs> to see what colors can be used.
-   * @default "primary"
    */
   activeColor?: string;
   /**
    * Space around separators.
-   * @default "sm"
    */
   gutter?: QBreadcrumbsGutterOptions;
   /**
    * Separator to use between the breadcrumb elements. To use an icon, prefix with "icon:" followed by the name of the icon.
-   * @default "/"
    */
   separator?: StringWithSuggestions<`icon:${MaterialSymbol}`> | Snippet;
   /**
    * Color to use for the separators. See <link to colors docs> to see what colors can be used.
-   * @default "outline"
    */
   separatorColor?: string;
 }
 
-export interface QBreadcrumbsElProps extends HTMLAttributes<HTMLLIElement> {
-  /**
-   * Class to apply to the breadcrumb element when the route is active.
-   * @default "active"
-   */
-  activeClass?: string;
+export interface QBreadcrumbsElProps
+  extends Linkable, WithActiveAttrs, Labelable, HTMLAttributes<HTMLLIElement> {
   /**
    * Name of the leading icon for the breadcrumb element. The icon prop overwrites to icon slot.
    */
   icon?: MaterialSymbol | Snippet;
   /**
-   * Text to use for the breadcrumb element. If default slot is defined, the label will be overwritten by it.
-   * @default ""
-   */
-  label?: string;
-  /**
-   * Also makes the breadcrumb element navigational. Can be used with the router (e.g to="/home") or as a normal href attribute (e.g to="#section-id")
-   */
-  href?: string;
-  /**
    * Tag to use for the breadcrumb element.
-   * @default "span"
    */
   tag?: string;
-  /**
-   * Makes the breadcrumb element navigational. Can be used with the router (e.g to="/home") or as a normal href attribute (e.g to="#section-id")
-   */
-  to?: string;
 }

--- a/src/lib/components/button/QBtn.svelte
+++ b/src/lib/components/button/QBtn.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import { useSize } from "$composables";
   import { ripple } from "$helpers";
-  import { isActivationKey, extractImgSrc, type QEvent } from "$utils";
+  import { isActivationKey, extractImgSrc, type QEvent, getRouterInfo } from "$utils";
   import QIcon from "$components/icon/QIcon.svelte";
   import QCircularProgress from "$components/progress/QCircularProgress.svelte";
   import type { MaterialSymbol } from "material-symbols";
@@ -25,7 +25,6 @@
     noRipple = false,
     rippleColor,
     round = false,
-    to,
     unelevated = false,
     size = "md",
     target,
@@ -42,7 +41,9 @@
   // #endregion: --- Non-reactive variables
 
   // #region:    --- Derived values
-  const computedTag = $derived(to ? "a" : tag || "button");
+  const routerInfo = $derived(getRouterInfo(props));
+
+  const computedTag = $derived(routerInfo.hasLink ? "a" : tag || "button");
   const qSize = $derived(useSize(size, "q-btn"));
 
   const src = $derived(extractImgSrc(icon));
@@ -116,7 +117,7 @@
       rectangle,
       round: round || (!children && !label),
     },
-    classes: [qSize.class, props.class],
+    classes: [qSize.class, routerInfo.linkClass, props.class],
   });
 </script>
 
@@ -129,7 +130,7 @@
   style:--q-btn-size={qSize.style}
   style:--ripple-color={computedColor && `var(--${computedColor})`}
   {target}
-  href={to}
+  {...routerInfo.linkAttributes}
   role={computedTag === "a" ? "button" : undefined}
   aria-disabled={disabled || undefined}
   tabindex={disabled ? -1 : props.tabindex || 0}

--- a/src/lib/components/button/props.ts
+++ b/src/lib/components/button/props.ts
@@ -1,18 +1,18 @@
-import type { QSize } from "$utils";
+import type { Disableable, Linkable, QSize, QSizeable, Labelable } from "$utils";
 import type { MaterialSymbol } from "material-symbols";
-import type { HTMLAttributes, HTMLAnchorAttributes, MouseEventHandler } from "svelte/elements";
+import type { HTMLAttributes, MouseEventHandler } from "svelte/elements";
 
 export type QBtnSizeOptions = Exclude<QSize, "xs">;
 
 export type QBtnVariantOptions = "elevated" | "filled" | "tonal" | "outlined" | "flat";
 
-export interface QBtnProps extends HTMLAttributes<HTMLButtonElement> {
-  /**
-   * Puts the button in a disabled state, making it unclickable.
-   * @default false
-   */
-  disabled?: boolean;
-
+export interface QBtnProps
+  extends
+    Labelable,
+    Disableable,
+    Linkable,
+    QSizeable<"none" | "xs">,
+    HTMLAttributes<HTMLButtonElement> {
   /**
    * Sets the color of the button. If a color is specified, it overwrites all other color variants defined with boolean attributes.
    */
@@ -53,11 +53,6 @@ export interface QBtnProps extends HTMLAttributes<HTMLButtonElement> {
   icon?: MaterialSymbol | `img:${string}`;
 
   /**
-   * Text to use for the button.
-   */
-  label?: string;
-
-  /**
    * Puts the button in a loading state, adding a loader as the leading icon.
    * @default false
    */
@@ -87,27 +82,10 @@ export interface QBtnProps extends HTMLAttributes<HTMLButtonElement> {
   round?: boolean;
 
   /**
-   * Makes the button navigational. Can be used with the router (e.g to="/home") or as a normal href attribute (e.g to="#section-id").
-   *  @default undefined
-   */
-  to?: string;
-
-  /**
    * Removes the button's elevation.
    * @default false
    */
   unelevated?: boolean;
-
-  /**
-   * Size of the button.
-   * @default "md"
-   */
-  size?: QBtnSizeOptions;
-
-  /**
-   * For "a" (anchor) tag only, apply the target attribute.
-   */
-  target?: HTMLAnchorAttributes["target"];
 
   /**
    * The tag to use for the button. If not specified, a button element will be used or, if `to` is specified, an anchor tag will be used.

--- a/src/lib/components/card/props.ts
+++ b/src/lib/components/card/props.ts
@@ -1,30 +1,22 @@
 import type { UseAlignProps } from "$composables";
+import { Borderable } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
 export type QCardFillColors = "primary" | "secondary" | "tertiary";
 
-export interface QCardProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * Adds a border around the card.
-   * @default false
-   */
-  bordered?: boolean;
-
+export interface QCardProps extends Borderable, HTMLAttributes<HTMLElement> {
   /**
    * Defines the fill color of the card.
-   * @default false
    */
   fill?: boolean | QCardFillColors;
 
   /**
    * Use the flat design for the card, removing its elevation.
-   * @default false
    */
   flat?: boolean;
 
   /**
    * Adds border radius to the card to round its corners.
-   * @default false
    */
   rounded?: boolean;
 }
@@ -32,7 +24,6 @@ export interface QCardProps extends HTMLAttributes<HTMLElement> {
 export interface QCardSectionProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Lays out the section content horizontally.
-   * @default false
    */
   horizontal?: boolean;
 }
@@ -40,7 +31,6 @@ export interface QCardSectionProps extends HTMLAttributes<HTMLDivElement> {
 export interface QCardActionsProps extends UseAlignProps, HTMLAttributes<HTMLElement> {
   /**
    * Lays out the action items vertically.
-   * @default false
    */
   vertical?: boolean;
 }

--- a/src/lib/components/checkbox/props.ts
+++ b/src/lib/components/checkbox/props.ts
@@ -1,19 +1,5 @@
+import { Disableable, Labelable, OptionalModel } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
-export interface QCheckboxProps extends HTMLAttributes<HTMLLabelElement> {
-  /**
-   * Controls the checked state of the checkbox.
-   *
-   * @bindable
-   */
-  value: boolean;
-  /**
-   * Sets the label for the checkbox.
-   */
-  label?: string;
-  /**
-   * Puts the checkbox in a disabled state, making it unclickable.
-   * @default false
-   */
-  disabled?: boolean;
-}
+export interface QCheckboxProps
+  extends OptionalModel<boolean>, Labelable, Disableable, HTMLAttributes<HTMLLabelElement> {}

--- a/src/lib/components/chip/props.ts
+++ b/src/lib/components/chip/props.ts
@@ -1,4 +1,4 @@
-import type { QSize } from "$utils";
+import type { Disableable, Labelable, QSizeable } from "$utils";
 import type { MaterialSymbol } from "material-symbols";
 import type { HTMLAttributes, MouseEventHandler } from "svelte/elements";
 
@@ -11,18 +11,12 @@ export type QChipFillOptions =
   | "neutral-variant"
   | "error";
 
-export type QChipSizeOptions = Exclude<QSize, "xs" | "xl" | "none">;
-
-export interface QChipProps extends HTMLAttributes<HTMLDivElement> {
+export interface QChipProps
+  extends QSizeable<"none" | "xs" | "xl">, Labelable, Disableable, HTMLAttributes<HTMLDivElement> {
   /**
    * The chip's kind. It will control the chip's style and behavior.
    */
   kind?: QChipKindOptions;
-
-  /**
-   * The chip's text content. Will overwrite the default slot.
-   */
-  label?: string;
 
   /**
    * Name of the leading icon to use for the chip. If starts with "img:", will be used as an image src instead.
@@ -35,35 +29,19 @@ export interface QChipProps extends HTMLAttributes<HTMLDivElement> {
   trailingIcon?: MaterialSymbol | `img:${string}`;
 
   /**
-   * Puts the chip in a disabled state, making it unactivable.
-   * @default false
-   */
-  disabled?: boolean;
-
-  /**
-   * Only for filter chips. Controls wether the chip is selected or not.
-   * @default false
-   * @bindable
+   * Only for filter chips. Controls wether the chip is selected or not..
    */
   selected?: boolean;
 
   /**
    * Elevates the button, giving it box-shadow and a background color.
-   * @default false
    */
   elevated?: boolean;
 
   /**
    * Disable the ripple effect for the chip.
-   * @default false
    */
   noRipple?: boolean;
-
-  /**
-   * Size of the chip.
-   * @default sm
-   */
-  size?: QChipSizeOptions;
 
   /**
    * Click event handler for the trailing icon of the chip. This can be useful with input chips to clear them.

--- a/src/lib/components/dialog/props.ts
+++ b/src/lib/components/dialog/props.ts
@@ -1,36 +1,26 @@
+import { OptionalModel } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
 export type QDialogPositionOptions = "default" | "top" | "right" | "bottom" | "left";
 
-export interface QDialogProps extends HTMLAttributes<HTMLDialogElement> {
-  /**
-   * The value indicating whether the dialog is visible or hidden.
-   * @default true
-   * @bindable
-   */
-  value?: boolean;
-
+export interface QDialogProps extends OptionalModel<boolean>, HTMLAttributes<HTMLDialogElement> {
   /**
    * The position of the dialog relative to the viewport.
-   * @default "default"
    */
   position?: QDialogPositionOptions;
 
   /**
    * Determines whether the dialog is displayed as a modal or not.
-   * @default false
    */
   modal?: boolean;
 
   /**
    * Determines whether the dialog is displayed in fullscreen mode.
-   * @default false
    */
   fullscreen?: boolean;
 
   /**
    * Determines whether the dialog remains persistent, not closing on click outside.
-   * @default false
    */
   persistent?: boolean;
 }

--- a/src/lib/components/drawer/props.ts
+++ b/src/lib/components/drawer/props.ts
@@ -1,80 +1,59 @@
+import { Borderable, OptionalModel } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
 export type QDrawerSideOptions = "left" | "right";
 export type QDrawerBehaviorOptions = "default" | "desktop" | "mobile";
 
-export interface QDrawerProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * The value indicating whether the drawer is visible or hidden.
-   * @default true
-   * @bindable
-   */
-  value?: boolean;
-
+export interface QDrawerProps
+  extends OptionalModel<boolean>, Borderable, HTMLAttributes<HTMLDivElement> {
   /**
    * The side of the layout where the drawer is positioned.
-   * @default "left"
    */
   side?: QDrawerSideOptions;
 
   /**
    * The width of the drawer. Can be specified with a CSS unit. If no unit is specified, "px" will be used.
-   * @default 300
    */
   width?: number;
 
   /**
    * The viewport width below which swipe gestures are enabled.
-   * @default 1023
    */
   breakpoint?: number;
 
   /**
    * Determines whether the drawer should be shown if the viewport width is above the specified breakpoint. (not supported yet)
-   * @default false
    */
   showIfAbove?: boolean;
 
   /**
    * Controls swipe behavior: "default" follows the breakpoint, "mobile" enables swiping and "desktop" disables it.
-   * @default "default"
    */
   behavior?: QDrawerBehaviorOptions;
 
   /**
-   * Determines whether the drawer has a border around it.
-   * @default false
-   */
-  bordered?: boolean;
-
-  /**
    * Determines whether the drawer has an elevated effect. (not supported yet)
-   * @default false
    */
   elevated?: boolean;
 
   /**
    * Determines whether the drawer should behave like an overlay (opening above the content) or not (pushing the content while opening).
-   * @default false
    */
   overlay?: boolean;
 
   /**
    * Determines whether the drawer remains persistent, not closing on click outside.
-   * @default false
    */
   persistent?: boolean;
 
   /**
    * Determines whether swipe gestures opening the drawer should be disabled or not.
-   * @default false
    */
   noSwipe?: boolean;
 
   /**
    * The threshold in percentage of the drawer width that must be swiped for the drawer to snap open/close.
    * This is only applicable if swipe gestures are enabled.
-   * @default "30%"
    */
   swipeThreshold?: `${number}%`;
 }

--- a/src/lib/components/expansion-item/props.ts
+++ b/src/lib/components/expansion-item/props.ts
@@ -1,19 +1,10 @@
 import { MaterialSymbol } from "material-symbols";
 import { Snippet } from "svelte";
 import { HTMLDetailsAttributes, MouseEventHandler } from "svelte/elements";
+import { Disableable, Labelable, Linkable, OptionalModel } from "$utils";
 
-export interface QExpansionItemProps extends HTMLDetailsAttributes {
-  /**
-   * The value of the expansion item, used to define the expansion state of the item.
-   * @bindable
-   */
-  value?: boolean;
-
-  /**
-   * The label of the expansion item, displayed in the header.
-   */
-  label?: string;
-
+export interface QExpansionItemProps
+  extends OptionalModel<boolean>, Labelable, Linkable, Disableable, HTMLDetailsAttributes {
   /**
    * The icon to display in the header of the expansion item.
    */
@@ -27,8 +18,6 @@ export interface QExpansionItemProps extends HTMLDetailsAttributes {
   /**
    * The icon to use as the toggle icon for the expansion item.
    * If not provided, a chevron icon will be used.
-   *
-   * @default "chevron_down"
    */
   expandIcon?: MaterialSymbol;
 
@@ -40,29 +29,21 @@ export interface QExpansionItemProps extends HTMLDetailsAttributes {
 
   /**
    * Whether the expansion item is initially expanded.
-   *
-   * @default false
    */
   defaultOpened?: boolean;
 
   /**
    * Use the dense style for the expansion item, reducing its height.
-   *
-   * @default false
    */
   dense?: boolean;
 
   /**
    * Duration for the expansion animation in milliseconds.
-   *
-   * @default 300
    */
   duration?: number;
 
   /**
    * Whether to hide the expand icon.
-   *
-   * @default false
    */
   hideExpandIcon?: boolean;
 
@@ -75,8 +56,6 @@ export interface QExpansionItemProps extends HTMLDetailsAttributes {
 
   /**
    * The aria-label for the toggle button of the expansion item for accessibility.
-   *
-   * @default "Open details"
    */
   toggleAriaLabel?: string;
 
@@ -84,39 +63,14 @@ export interface QExpansionItemProps extends HTMLDetailsAttributes {
    * Makes the toggle icon the trigger for the expansion item instead of the whole header.
    * This is useful when using the expansion item as link, so the icon allows to expand/collapse the item
    * while the header changes the route.
-   *
-   * @default false
    */
   expandIconToggle?: boolean;
 
   /**
-   * Make the expansion item navigational, allowing it to be used as a link.
-   * It can be used interchangeably with the `href` prop.
-   * If both `href` and `to` are provided, the `to` prop will take precedence.
-   */
-  to?: string;
-
-  /**
-   * The URL to navigate to when the expansion item is clicked.
-   * It can be used interchangeably with the `to` prop.
-   * If both `href` and `to` are provided, the `to` prop will take precedence.
-   */
-  href?: string;
-
-  /**
    * Prevents the rotation of the expand icon when the item is expanded.
    * This is useful when using a custom icon that does not need to be rotated.
-   *
-   * @default false
    */
   noRotateExpandIcon?: boolean;
-
-  /**
-   * Whether the expansion item is disabled.
-   *
-   * @default false
-   */
-  disabled?: boolean;
 
   /**
    * Disables the ripple effect on the expansion item.

--- a/src/lib/components/footer/props.ts
+++ b/src/lib/components/footer/props.ts
@@ -1,27 +1,15 @@
+import { Borderable, OptionalModel } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
-export interface QFooterProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * The value indicating whether the footer is visible or hidden.
-   * @default true
-   */
-  value?: boolean;
-
-  /**
-   * Determines whether the footer has a top border.
-   * @default false
-   */
-  bordered?: boolean;
-
+export interface QFooterProps
+  extends OptionalModel<boolean>, Borderable, HTMLAttributes<HTMLElement> {
   /**
    * Determines whether the footer should hide on scroll.
-   * @default false
    */
   reveal?: boolean;
 
   /**
    * The offset in pixels to trigger the reveal effect. The footer will be hidden when the scroll position is greater than this value.
-   * @default 250
    */
   revealOffset?: number;
 

--- a/src/lib/components/header/props.ts
+++ b/src/lib/components/header/props.ts
@@ -1,36 +1,29 @@
 import { HTMLAttributes } from "svelte/elements";
+import { Borderable } from "$utils";
 
-export interface QHeaderProps extends HTMLAttributes<HTMLElement> {
+export interface QHeaderProps extends Borderable, HTMLAttributes<HTMLElement> {
   /**
    * Adds horizontal padding to the toolbar content.
-   *
-   * @default false
    */
   inset?: boolean;
+
   /**
-   * Adds a border to the toolbar to separate it from the main content.
-   *
-   * @default false
-   */
-  border?: boolean;
-  /**
-   * @default false
+   * Adds a drop shadow to the toolbar.
    */
   elevated?: boolean;
+
   /**
-   * @default false
-   */
-  bordered?: boolean;
-  /**
-   * @default 64
+   * Height in pixels of the toolbar.
    */
   height?: number;
+
   /**
-   * @default false
+   * Hides the toolbar when the user scrolls down the page and shows the toolbar when the user scrolls up the page.
    */
   reveal?: boolean;
+
   /**
-   * @default 250
+   * The offset in pixels to trigger the reveal effect. The toolbar will be hidden when the scroll position is greater than this value.
    */
   revealOffset?: number;
 }

--- a/src/lib/components/icon/props.ts
+++ b/src/lib/components/icon/props.ts
@@ -1,4 +1,4 @@
-import type { CssValue, QSize } from "$utils";
+import type { CssValue, QSize, Sizeable } from "$utils";
 import type { HTMLAttributes, HTMLImgAttributes } from "svelte/elements";
 import type { MaterialSymbol } from "material-symbols";
 
@@ -6,12 +6,7 @@ export type QIconSizeOptions = QSize | CssValue | number;
 
 export type QIconTypeOptions = "outlined" | "sharp" | "rounded";
 
-export interface QIconProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * The size of the icon. Can be specified with CSS units. If no unit is specified, "px" will be used.
-   */
-  size?: QIconSizeOptions;
-
+export interface QIconProps extends Sizeable, HTMLAttributes<HTMLElement> {
   /**
    * The type of the icon.
    */

--- a/src/lib/components/icon/props.ts
+++ b/src/lib/components/icon/props.ts
@@ -9,13 +9,11 @@ export type QIconTypeOptions = "outlined" | "sharp" | "rounded";
 export interface QIconProps extends HTMLAttributes<HTMLElement> {
   /**
    * The size of the icon. Can be specified with CSS units. If no unit is specified, "px" will be used.
-   * @default md
    */
   size?: QIconSizeOptions;
 
   /**
    * The type of the icon.
-   * @default outlined
    */
   type?: QIconTypeOptions;
 
@@ -26,7 +24,6 @@ export interface QIconProps extends HTMLAttributes<HTMLElement> {
 
   /**
    * Determines whether the icon should be filled.
-   * @default false
    */
   filled?: boolean;
 
@@ -42,7 +39,6 @@ export interface QIconProps extends HTMLAttributes<HTMLElement> {
 
   /**
    * Additional attributes for the image element when using the `img` prop, as for example the "alt" attribute.
-   * @default {}
    */
   imgAttributes?: HTMLImgAttributes;
 

--- a/src/lib/components/input/props.ts
+++ b/src/lib/components/input/props.ts
@@ -1,26 +1,21 @@
+import { Disableable, Labelable, OptionalModel } from "$utils";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes, HTMLInputAttributes } from "svelte/elements";
 import type { QInputFillMask } from "./mask";
 
-export interface QInputProps extends HTMLInputAttributes {
+export interface QInputProps
+  extends
+    OptionalModel<string | number | null>,
+    Labelable,
+    Disableable,
+    Omit<HTMLInputAttributes, "value" | "disabled"> {
   /**
    * Makes the input component more compact.
-   *
-   * @default false
    */
   dense?: boolean;
 
   /**
-   * Disables the input, preventing user interaction.
-   *
-   * @default false
-   */
-  disabled?: boolean;
-
-  /**
    * Indicates an error state for the input.
-   *
-   * @default false
    */
   error?: boolean;
 
@@ -32,8 +27,6 @@ export interface QInputProps extends HTMLInputAttributes {
 
   /**
    * Applies a filled background style to the input.
-   *
-   * @default false
    */
   filled?: boolean;
 
@@ -44,22 +37,12 @@ export interface QInputProps extends HTMLInputAttributes {
   hint?: string;
 
   /**
-   * Label text for the input field.
-   *
-   */
-  label?: string;
-
-  /**
    * Applies an outlined style to the input.
-   *
-   * @default false
    */
   outlined?: boolean;
 
   /**
    * Makes the sides of the input round.
-   *
-   * @default false
    */
   rounded?: boolean;
 
@@ -77,16 +60,8 @@ export interface QInputProps extends HTMLInputAttributes {
 
   /**
    * Stores only mask token characters in the bindable value.
-   *
-   * @default false
    */
   unmaskedValue?: boolean;
-
-  /**
-   * Current value of the input field.
-   * @bindable
-   */
-  value: string | number | null;
 
   /**
    * Classes applied to the field wrapper.

--- a/src/lib/components/layout/props.ts
+++ b/src/lib/components/layout/props.ts
@@ -8,7 +8,6 @@ export interface QLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * The layout view configuration, which defines how layout components (header, railbars, drawers, footer) should be displayed on screen.
    * Controls how layout components (header, railbars, drawers, footer) are displayed on screen.
-   * @default "hhh lpr fff"
    */
   view?: QLayoutViewOptions;
 

--- a/src/lib/components/list/QItem.svelte
+++ b/src/lib/components/list/QItem.svelte
@@ -22,6 +22,7 @@
     active = false,
     clickable = false,
     dense = false,
+    tabindex = 0,
     disabled = false,
     activeStyle,
     noRipple = false,
@@ -73,10 +74,13 @@
 {/if}
 
 {#if routerInfo.hasLink}
+  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
   <a
     {@attach ripple({ disabled: !isClickable || noRipple })}
     {...props}
     class="q-item"
+    tabindex={isClickable ? tabindex || 0 : undefined}
+    aria-disabled={isActionable && disabled ? true : undefined}
     {...routerInfo.linkAttributes}
     data-quaff
     {style}
@@ -89,6 +93,8 @@
     {@attach ripple({ disabled: !isClickable || noRipple })}
     {...props}
     class="q-item"
+    tabindex={isClickable ? tabindex || 0 : undefined}
+    aria-disabled={isActionable && disabled ? true : undefined}
     {...routerInfo.linkAttributes}
     data-quaff
     {style}

--- a/src/lib/components/list/QItem.svelte
+++ b/src/lib/components/list/QItem.svelte
@@ -2,7 +2,7 @@
   import { QContext } from "$utils/context";
 
   interface QItemContext {
-    readonly activeClass: string | false;
+    readonly activeClass: string | undefined;
     multiline: boolean;
   }
 
@@ -11,7 +11,7 @@
 
 <script lang="ts">
   import { ripple } from "$helpers";
-  import { getRouterInfo, isRouteActive } from "$utils";
+  import { getRouterInfo } from "$utils";
   import QSeparator from "../separator/QSeparator.svelte";
   import { listCtx } from "./QList.svelte";
   import type { QItemProps } from "./props";
@@ -22,12 +22,8 @@
     active = false,
     clickable = false,
     dense = false,
-    tabindex = 0,
-    href,
-    to,
     disabled = false,
-    activeClass = "active",
-    replace = false,
+    activeStyle,
     noRipple = false,
     children,
     ...props
@@ -41,30 +37,23 @@
   // #endregion: --- Reactive variables
 
   // #region:    --- Derived values
-  const routerInfo = $derived(
-    getRouterInfo({
-      href,
-      to,
-      disabled,
-      activeClass,
-      replace,
-    })
-  );
+  const routerInfo = $derived(getRouterInfo(props));
 
-  const activeClassToUse = $derived(
-    activeClass === "active" ? ctx.activeClass || activeClass : activeClass
-  );
-
+  const isActive = $derived(routerInfo.isActive || active);
   const isActionable = $derived(clickable || routerInfo.hasLink || tag === "label");
   const isClickable = $derived(isActionable && !disabled);
 
-  const isActive = $derived(isRouteActive(to || href) || active);
+  const activeClass = $derived((isActive && (props.activeClass ?? ctx.activeClass)) || undefined);
+  const style = $derived(
+    [isActive && (ctx.activeStyle ?? activeStyle), props.style].filter(Boolean).join("; ") ||
+      undefined
+  );
   // #endregion: --- Derived values
 
   // #region:    --- Context
   itemCtx.set({
     multiline,
-    activeClass: active && activeClassToUse,
+    activeClass,
   });
   // #endregion: --- Context
 
@@ -75,7 +64,7 @@
       active: isActive,
       clickable,
     },
-    classes: [routerInfo.linkClasses, isActive && activeClassToUse, props.class],
+    classes: [routerInfo.linkClass, activeClass, props.class],
   });
 </script>
 
@@ -83,16 +72,14 @@
   <QSeparator {...ctx.separatorOptions} />
 {/if}
 
-{#if routerInfo.linkAttributes.href}
-  <!-- svelte-ignore a11y_no_noninteractive_tabindex -->
+{#if routerInfo.hasLink}
   <a
     {@attach ripple({ disabled: !isClickable || noRipple })}
     {...props}
     class="q-item"
-    tabindex={isClickable ? tabindex || 0 : undefined}
-    aria-disabled={isActionable && disabled ? true : undefined}
     {...routerInfo.linkAttributes}
     data-quaff
+    {style}
   >
     {@render children?.()}
   </a>
@@ -102,9 +89,9 @@
     {@attach ripple({ disabled: !isClickable || noRipple })}
     {...props}
     class="q-item"
-    tabindex={isClickable ? tabindex || 0 : undefined}
-    aria-disabled={isActionable && disabled ? true : undefined}
+    {...routerInfo.linkAttributes}
     data-quaff
+    {style}
   >
     {@render children?.()}
   </svelte:element>

--- a/src/lib/components/list/QItemSection.svelte
+++ b/src/lib/components/list/QItemSection.svelte
@@ -54,7 +54,7 @@
   {:else if type === "side"}
     {@render children?.()}
   {:else}
-    <div class={ctx.activeClass || undefined}>
+    <div class={ctx.activeClass}>
       {@render children?.()}
     </div>
   {/if}

--- a/src/lib/components/list/QList.svelte
+++ b/src/lib/components/list/QList.svelte
@@ -4,6 +4,7 @@
 
   interface QListContext {
     readonly activeClass: string | undefined;
+    readonly activeStyle: string | undefined;
     readonly separatorOptions: QListProps["separatorOptions"];
   }
 
@@ -21,6 +22,7 @@
     padding = false,
     tag = "div",
     activeClass,
+    activeStyle,
     children,
     ...props
   }: QListProps = $props();
@@ -33,6 +35,7 @@
   // #region:    --- Context
   listCtx.set({
     activeClass,
+    activeStyle,
     separatorOptions: separator ? separatorOptions : undefined,
   });
   // #endregion: --- Context

--- a/src/lib/components/list/props.ts
+++ b/src/lib/components/list/props.ts
@@ -1,34 +1,26 @@
-import type { RouterProps } from "$utils";
+import type { Disableable, Linkable, WithActiveAttrs } from "$utils";
 import type { Snippet } from "svelte";
 import type { QSeparatorHorizontalProps } from "../separator/props";
 import type { HTMLAnchorAttributes, HTMLAttributes } from "svelte/elements";
 
-export interface QListProps extends HTMLAttributes<HTMLElement> {
+export interface QListProps extends WithActiveAttrs, HTMLAttributes<HTMLElement> {
   /**
    * Adds a border around the list.
-   *
-   * @default false
    */
   bordered?: boolean;
 
   /**
    * Removes the rounded borders when bordered is true.
-   *
-   * @default false
    */
   noRound?: boolean;
 
   /**
    * Makes all the items in the list more compact.
-   *
-   * @default false
    */
   dense?: boolean;
 
   /**
    * Adds separators between list items.
-   *
-   * @default false
    */
   separator?: boolean;
 
@@ -40,71 +32,44 @@ export interface QListProps extends HTMLAttributes<HTMLElement> {
 
   /**
    * Adds padding to the list container.
-   *
-   * @default true
    */
   padding?: boolean;
 
   /**
    * HTML tag to be used for the list container.
-   *
-   * @default "div"
    */
   tag?: string;
-
-  /**
-   * The class to apply to items that are active. For more granular control, you can also use the `activeClass` prop on each QItem.
-   *
-   */
-  activeClass?: string;
 }
 
-export interface QItemProps extends RouterProps, HTMLAttributes<HTMLElement> {
+export interface QItemProps
+  extends Linkable, Disableable, WithActiveAttrs, HTMLAttributes<HTMLElement> {
   /**
    * HTML tag to be used for the list item.
-   *
-   * @default "div"
    */
   tag?: string;
 
   /**
    * Indicates if the item is currently active.
-   *
-   * @default false
    */
   active?: boolean;
 
   /**
    * Makes the item clickable and adds hover effects.
-   *
-   * @default false
    */
   clickable?: boolean;
 
   /**
    * Makes the item more compact.
-   *
-   * @default false
    */
   dense?: boolean;
 
   /**
    * Disables the ripple effect when clicking the item.
-   *
-   * @default false
    */
   noRipple?: boolean;
 
   /**
-   * Tab index for keyboard navigation.
-   *
-   * @default 0
-   */
-  tabindex?: HTMLAttributes<HTMLElement>["tabindex"];
-
-  /**
    * Target attribute for anchor tags when using router links.
-   *
    */
   target?: HTMLAnchorAttributes["target"];
 }
@@ -123,33 +88,26 @@ export type QItemSectionTypes =
 export interface QItemSectionProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Type of the section, determines its layout and styling.
-   *
-   * @default "content"
    */
   type?: QItemSectionTypes;
 
   /**
    * Main content or title of the section. By default, inherits the content of the children snippet.
-   *
-   * @default children
    */
   headline?: Snippet;
 
   /**
    * First line of supporting text.
-   *
    */
   line1?: Snippet;
 
   /**
    * Second line of supporting text.
-   *
    */
   line2?: Snippet;
 
   /**
    * Third line of supporting text.
-   *
    */
   line3?: Snippet;
 }

--- a/src/lib/components/menu/props.ts
+++ b/src/lib/components/menu/props.ts
@@ -1,3 +1,4 @@
+import { OptionalModel } from "$utils";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 
@@ -12,53 +13,34 @@ export type QMenuAnchor =
   | "bottom middle"
   | "bottom right";
 
-export interface QMenuProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * Bound open state.
-   *
-   * @default false
-   * @bindable
-   */
-  value?: boolean;
-
+export interface QMenuProps extends OptionalModel<boolean>, HTMLAttributes<HTMLDivElement> {
   /**
    * Element to anchor the menu to. When omitted, QMenu anchors to the nearest parent Quaff component.
-   *
    */
   target?: HTMLElement;
 
   /**
    * Anchor point on the target element.
-   *
-   * @default "bottom left"
    */
   anchor?: QMenuAnchor;
 
   /**
    * Anchor point on the menu element.
-   *
-   * @default "top left"
    */
   self?: QMenuAnchor;
 
   /**
    * Sets the menu width to the target width.
-   *
-   * @default false
    */
   fit?: boolean;
 
   /**
    * Prevents outside click dismissal.
-   *
-   * @default false
    */
   persistent?: boolean;
 
   /**
    * Closes the menu when its content is clicked.
-   *
-   * @default true
    */
   autoClose?: boolean;
 

--- a/src/lib/components/progress/props.ts
+++ b/src/lib/components/progress/props.ts
@@ -1,173 +1,108 @@
-import { CssValue } from "$utils";
+import { CssSizeable, CssValue, OptionalModel } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
-export interface QLinearProgressProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * Current progress value as a percentage.
-   * @default 0
-   * @bindable
-   */
-  value?: number;
-
+export interface QLinearProgressProps
+  extends OptionalModel<number>, CssSizeable, HTMLAttributes<HTMLDivElement> {
   /**
    * Secondary progress value, shown as a lighter track behind the main progress.
-   *
    */
   buffer?: number;
 
   /**
-   * Height of the progress bar.
-   *
-   * @default "0.375em"
-   */
-  size?: CssValue | number;
-
-  /**
    * Reverses the progress bar direction from right-to-left.
-   *
-   * @default false
    */
   reverse?: boolean;
 
   /**
    * Removes the rounded sides of the progress bar.
-   *
-   * @default false
    */
   noRound?: boolean;
 
   /**
    * Disables the transition animation when the value changes.
-   *
-   * @default false
    */
   instantFeedback?: boolean;
 
   /**
    * Color of the progress indicator.
-   *
-   * @default "primary"
    */
   color?: string;
 
   /**
    * Color of the background track.
-   *
-   * @default "secondary-container"
    */
   trackColor?: string;
 
   /**
    * Duration of the transition animation in milliseconds.
-   *
-   * @default 600
    */
   animationSpeed?: number;
 
   /**
    * Enables an infinite loading animation instead of showing progress.
-   *
-   * @default false
    */
   indeterminate?: boolean;
 }
 
-export interface QCircularProgressProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * Current progress value as a percentage. This prop is bindable.
-   *
-   * @default 0
-   */
-  value?: number;
-
+export interface QCircularProgressProps
+  extends OptionalModel<number>, CssSizeable, HTMLAttributes<HTMLDivElement> {
   /**
    * Enables an infinite spinning animation instead of showing progress.
-   *
-   * @default false
    */
   indeterminate?: boolean;
 
   /**
    * Removes the rounded ends of the progress arc.
-   *
-   * @default false
    */
   noRound?: boolean;
 
   /**
-   * Overall size of the circular progress component.
-   *
-   * @default "2em"
-   */
-  size?: CssValue | number;
-
-  /**
    * Color of the progress arc.
-   *
-   * @default "primary"
    */
   color?: string;
 
   /**
    * Color of the background circle.
-   *
-   * @default "secondary-container"
    */
   trackColor?: string;
 
   /**
    * Thickness of the progress arc.
-   *
-   * @default 0.2
    */
   thickness?: number;
 
   /**
    * Minimum value for the progress range.
-   *
-   * @default 0
    */
   min?: number;
 
   /**
    * Maximum value for the progress range.
-   *
-   * @default 100
    */
   max?: number;
 
   /**
    * Rotation angle of the progress arc in degrees (top is 0 and bottom 180).
-   *
-   * @default 0
    */
   angle?: number;
 
   /**
    * Shows the current progress value in the center of the circle.
-   *
-   * @default false
    */
   showValue?: boolean;
 
   /**
    * Disables the transition animation when the value changes.
-   *
-   * @default false
    */
   instantFeedback?: boolean;
 
   /**
    * Duration of the transition animation in milliseconds.
-   *
-   * @default 600
    */
   animationSpeed?: number;
 
   /**
    * Font size of the center text when showValue is true.
-   *
-   * @default "0.25em"
    */
   fontSize?: CssValue | number;
 }

--- a/src/lib/components/radio/props.ts
+++ b/src/lib/components/radio/props.ts
@@ -5,30 +5,22 @@ export type QRadioValue = string | number | boolean | null;
 export interface QRadioProps extends HTMLAttributes<HTMLLabelElement> {
   /**
    * Value associated with this radio button. Used when comparing against the selected value.
-   *
-   * @default ""
-   * @bindable
    */
   value: QRadioValue;
 
   /**
    * Text label displayed next to the radio button.
-   *
-   * @default ""
    */
   label?: string;
 
   /**
    * Bound value that determines if this radio button is selected. This prop is bindable.
    * When using a group of radio buttons, this should be the same variable for all of them.
-   *
    */
   selected?: QRadioValue;
 
   /**
    * When true, prevents user interaction with the radio button.
-   *
-   * @default false
    */
   disabled?: boolean;
 }

--- a/src/lib/components/railbar/props.ts
+++ b/src/lib/components/railbar/props.ts
@@ -1,24 +1,14 @@
+import { Borderable } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
-export interface QRailbarProps extends HTMLAttributes<HTMLElement> {
+export interface QRailbarProps extends Borderable, HTMLAttributes<HTMLElement> {
   /**
    * Width of the railbar in pixels.
-   *
-   * @default 88
    */
   width?: number;
 
   /**
    * Position of the railbar on the screen.
-   *
-   * @default left
    */
   side?: "left" | "right";
-
-  /**
-   * Adds a border to the railbar to separate it from the main content.
-   *
-   * @default false
-   */
-  bordered?: boolean;
 }

--- a/src/lib/components/select/props.ts
+++ b/src/lib/components/select/props.ts
@@ -10,14 +10,11 @@ export type QSelectFilterUpdate = (callbackFn: () => void | Promise<void>) => vo
 export interface QSelectProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Current value of the select. Can be a single value or an array of values when multiple is true.
-   * @bindable
    */
   value: QSelectValue;
 
   /**
    * Enables multiple selection mode.
-   *
-   * @default false
    */
   multiple?: boolean;
 
@@ -30,102 +27,76 @@ export interface QSelectProps extends HTMLAttributes<HTMLDivElement> {
 
   /**
    * Makes the select component more compact.
-   *
-   * @default false
    */
   dense?: boolean;
 
   /**
    * Disables the select, preventing user interaction.
-   *
-   * @default false
    */
   disabled?: boolean;
 
   /**
    * Indicates an error state for the select.
-   *
-   * @default false
    */
   error?: boolean;
 
   /**
    * Message to display when the select is in an error state.
-   *
    */
   errorMessage?: string;
 
   /**
    * Applies a filled background style to the select.
-   *
-   * @default false
    */
   filled?: boolean;
 
   /**
    * Helper text displayed below the select.
-   *
    */
   hint?: string;
 
   /**
    * Label text for the select field.
-   *
    */
   label?: string;
 
   /**
    * Applies an outlined style to the select.
-   *
-   * @default false
    */
   outlined?: boolean;
 
   /**
    * Makes the sides of the select round.
-   *
-   * @default false
    */
   rounded?: boolean;
 
   /**
    * Custom text to display in the select instead of the selected value.
-   *
    */
   displayValue?: string;
 
   /**
    * Indicates whether to emit the value rather than the entire option object when a value is selected.
-   *
-   * @default false
    */
   emitValue?: boolean;
 
   /**
    * Allows typing into the select field.
-   *
-   * @default false
    */
   useInput?: boolean;
 
   /**
    * Filters options by their label while typing. Requires useInput.
-   *
-   * @default false
    */
   filterable?: boolean;
 
   /**
    * Delay in milliseconds before calling onFilter after input changes.
-   *
-   * @default 300
    */
   inputDebounce?: number;
 
   /**
    * Text shown when no options are available.
-   *
-   * @default "No options"
    */
   noOptionText?: string;
 
@@ -140,25 +111,21 @@ export interface QSelectProps extends HTMLAttributes<HTMLDivElement> {
 
   /**
    * Content to be placed before the select wrapper element, usually an icon.
-   *
    */
   before?: Snippet;
 
   /**
    * Content to be placed at the start of the select field, usually an icon.
-   *
    */
   prepend?: Snippet;
 
   /**
    * Content to be placed at the end of the select field, before the dropdown arrow, usually an icon.
-   *
    */
   append?: Snippet;
 
   /**
    * Content to be placed after the select wrapper element, usually an icon.
-   *
    */
   after?: Snippet;
 }

--- a/src/lib/components/separator/props.ts
+++ b/src/lib/components/separator/props.ts
@@ -4,47 +4,36 @@ import type { HTMLAttributes } from "svelte/elements";
 export interface QSeparatorVerticalProps {
   /**
    * Spacing around the separator.
-   *
-   * @default "none"
    */
   spacing?: QSize;
 
   /**
    * Adds horizontal padding to the separator container, adding space around the separator.
-   *
-   * @default false
    */
   inset?: boolean;
 
   /**
    * Sets the separator orientation to vertical.
-   *
    */
   vertical?: true;
 
   /**
    * Color of the separator line.
-   *
-   * @default "outline"
    */
   color?: string;
 
   /**
    * Custom size (thickness) of the separator line.
-   *
    */
   size?: string;
 
   /**
    * Text to display. Its position on the separator is determined by the textAlign prop.
-   *
    */
   text?: string;
 
   /**
    * Vertical alignment of the text when text prop is used.
-   *
-   * @default "middle"
    */
   textAlign?: "top" | "middle" | "bottom";
 }
@@ -52,47 +41,36 @@ export interface QSeparatorVerticalProps {
 export interface QSeparatorHorizontalProps {
   /**
    * Spacing around the separator.
-   *
-   * @default "none"
    */
   spacing?: QSize;
 
   /**
    * Adds vertical padding to the separator container, adding space around the separator.
-   *
-   * @default false
    */
   inset?: boolean;
 
   /**
    * Sets the separator orientation to horizontal.
-   *
    */
   vertical?: false;
 
   /**
    * Color of the separator line.
-   *
-   * @default "outline"
    */
   color?: string;
 
   /**
    * Custom size (thickness) of the separator line.
-   *
    */
   size?: string;
 
   /**
    * Text to display. Its position on the separator is determined by the textAlign prop.
-   *
    */
   text?: string;
 
   /**
    * Horizontal alignment of the text when text prop is used.
-   *
-   * @default "center"
    */
   textAlign?: "left" | "center" | "right";
 }

--- a/src/lib/components/switch/props.ts
+++ b/src/lib/components/switch/props.ts
@@ -1,60 +1,32 @@
+import { Disableable, Labelable, OptionalModel } from "$utils";
 import type { MaterialSymbol } from "material-symbols";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 
-export interface QSwitchProps extends HTMLAttributes<HTMLDivElement> {
-  /**
-   * Current on/off state of the switch.
-   *
-   * @bindable
-   */
-  value?: boolean;
-
-  /**
-   * Text label to display next to the switch.
-   *
-   */
-  label?: string;
-
+export interface QSwitchProps
+  extends OptionalModel<boolean>, Labelable, Disableable, HTMLAttributes<HTMLDivElement> {
   /**
    * Position of the label relative to the switch.
-   *
-   * @default "right"
    */
   labelPosition?: "left" | "right";
 
   /**
    * Shows default check/close icons in the switch handle.
-   *
-   * @default false
    */
   icons?: boolean;
 
   /**
    * When true, only shows the check icon (when the switch is on).
-   *
-   * @default false
    */
   showOnlyCheckedIcon?: boolean;
 
   /**
    * Custom icon to show when the switch is on. Can be a Material Symbol name or a custom snippet.
-   *
-   * @default "check"
    */
   checkedIcon?: MaterialSymbol | Snippet;
 
   /**
    * Custom icon to show when the switch is off. Can be a Material Symbol name or a custom snippet.
-   *
-   * @default "close"
    */
   uncheckedIcon?: MaterialSymbol | Snippet;
-
-  /**
-   * Disables the switch, preventing user interaction.
-   *
-   * @default false
-   */
-  disabled?: boolean;
 }

--- a/src/lib/components/table/props.ts
+++ b/src/lib/components/table/props.ts
@@ -1,3 +1,4 @@
+import { Borderable } from "$utils";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 
@@ -21,34 +22,24 @@ export type QTableSort = {
   type: "asc" | "desc";
 } | null;
 
-export interface QTableProps extends HTMLAttributes<HTMLDivElement> {
+export interface QTableProps extends Borderable, HTMLAttributes<HTMLDivElement> {
   /**
    * Column definitions of the table.
-   * @default []
    */
   columns: QTableColumn[];
 
   /**
    * Rows of the table.
-   * @default []
    */
   rows: QTableRow[];
 
   /**
    * Uses flat design, removing the box-shadow around the table.
-   * @default false
    */
   flat?: boolean;
 
   /**
-   * Adds a border around the table.
-   * @default false
-   */
-  bordered?: boolean;
-
-  /**
    * Shows the Table in dense mode (takes up less space).
-   * @default false
    */
   dense?: boolean;
 

--- a/src/lib/components/tabs/QTab.svelte
+++ b/src/lib/components/tabs/QTab.svelte
@@ -4,9 +4,9 @@
     getClosestFocusableBlock,
     getClosestFocusableSibling,
     getDirection,
+    getRouterInfo,
     isActivationKey,
     isArrowKey,
-    isRouteActive,
     isTabKey,
     type Direction,
     type QEvent,
@@ -19,7 +19,7 @@
   type QTabEvent<T extends Event> = QEvent<T, QTabEl>;
 
   // #region:    --- Props
-  let { name, to, icon, children, ...props }: QTabProps = $props();
+  let { name, icon, children, ...props }: QTabProps = $props();
   // #endregion: --- Props
 
   // #region:    --- Non-reactive variables
@@ -31,9 +31,12 @@
   // #endregion: --- Reactive variables
 
   // #region:    --- Derived values
-  const tag = $derived(to ? "a" : "button");
+  const routerInfo = $derived(getRouterInfo(props));
+  const tag = $derived(routerInfo.hasLink ? "a" : "button");
 
-  const isActive = $derived(to ? isRouteActive(to) : name === ctx.value);
+  const isActive = $derived(routerInfo.isActive ?? name === ctx.value);
+
+  const activeClass = $derived(isActive && (props.activeClass ?? ctx.activeClass));
   // #endregion: --- Derived values
 
   // #region:    --- Functions
@@ -83,7 +86,7 @@
     bemClasses: {
       active: isActive,
     },
-    classes: [props.class],
+    classes: [routerInfo.linkClass, activeClass, props.class],
   });
 </script>
 
@@ -92,8 +95,8 @@
   bind:this={qTab}
   {@attach ripple()}
   {...props}
+  {...routerInfo.linkAttributes}
   class="q-tab"
-  href={to}
   role={tag === "a" ? "button" : undefined}
   aria-current={isActive || undefined}
   aria-label={name}

--- a/src/lib/components/tabs/QTabs.svelte
+++ b/src/lib/components/tabs/QTabs.svelte
@@ -4,6 +4,8 @@
 
   interface QTabsContext {
     readonly variant: QTabsProps["variant"];
+    readonly activeClass: QTabsProps["activeClass"];
+    readonly activeStyle: QTabsProps["activeStyle"];
     value: QTabsProps["value"];
     request: string | null;
   }
@@ -20,6 +22,8 @@
     value = $bindable(),
     variant = "primary",
     noSeparator = false,
+    activeClass,
+    activeStyle,
     children,
     ...props
   }: QTabsProps = $props();
@@ -35,7 +39,7 @@
   // #endregion: --- Reactive variables
 
   // #region:    --- Context
-  tabsCtx.set({ value, variant, request });
+  tabsCtx.set({ value, activeClass, activeStyle, variant, request });
   // #endregion: --- Context
 
   // #region:    --- Effects

--- a/src/lib/components/tabs/props.ts
+++ b/src/lib/components/tabs/props.ts
@@ -1,33 +1,24 @@
+import { OptionalModel, WithActiveAttrs } from "$utils";
 import type { MaterialSymbol } from "material-symbols";
 import type { Snippet } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 
 export type QTabsVariants = "primary" | "secondary" | "vertical";
 
-export interface QTabsProps extends HTMLAttributes<HTMLElement> {
-  /**
-   * Current active tab name. This property is bindable.
-   *
-   * @bindable
-   */
-  value?: string;
-
+export interface QTabsProps
+  extends OptionalModel<string>, WithActiveAttrs, HTMLAttributes<HTMLElement> {
   /**
    * Visual style variant of the tabs.
-   *
-   * @default "primary"
    */
   variant?: QTabsVariants;
 
   /**
    * Removes the separator line under the tabs (or to the right for vertical tabs).
-   *
-   * @default false
    */
   noSeparator?: boolean;
 }
 
-export interface QTabProps extends HTMLAttributes<HTMLElement> {
+export interface QTabProps extends WithActiveAttrs, HTMLAttributes<HTMLElement> {
   /**
    * Unique identifier for the tab. Used to match with QTabs' value prop.
    */
@@ -36,13 +27,11 @@ export interface QTabProps extends HTMLAttributes<HTMLElement> {
   /**
    * Navigation target URL when the tab is used as a router link.
    * When provided, the tab will render as an anchor tag.
-   *
    */
   to?: string;
 
   /**
    * Icon to display in the tab. Can be a Material Symbol name or a custom snippet.
-   *
    */
   icon?: MaterialSymbol | Snippet;
 }

--- a/src/lib/components/toolbar/QToolbar.svelte
+++ b/src/lib/components/toolbar/QToolbar.svelte
@@ -4,7 +4,7 @@
   // #region:    --- Props
   let {
     inset = false,
-    border = false,
+    bordered = false,
     elevate = false,
     height = 64,
     children,
@@ -16,7 +16,7 @@
     bemClasses: {
       inset,
       elevated: elevate,
-      bordered: border,
+      bordered,
     },
     classes: [props.class],
   });

--- a/src/lib/components/toolbar/props.ts
+++ b/src/lib/components/toolbar/props.ts
@@ -1,31 +1,19 @@
+import { Borderable } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
-export interface QToolbarProps extends HTMLAttributes<HTMLElement> {
+export interface QToolbarProps extends Borderable, HTMLAttributes<HTMLElement> {
   /**
    * Adds horizontal padding to the toolbar content.
-   *
-   * @default false
    */
   inset?: boolean;
 
   /**
-   * Adds a border to the toolbar to separate it from the main content.
-   *
-   * @default false
-   */
-  border?: boolean;
-
-  /**
    * Adds a shadow to the toolbar to make it appear elevated.
-   *
-   * @default false
    */
   elevate?: boolean;
 
   /**
    * Height of the toolbar in pixels.
-   *
-   * @default 64
    */
   height?: number;
 }
@@ -33,8 +21,6 @@ export interface QToolbarProps extends HTMLAttributes<HTMLElement> {
 export interface QToolbarTitleProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Allows the title to shrink when there isn't enough space in the toolbar.
-   *
-   * @default false
    */
   shrink?: boolean;
 }

--- a/src/lib/components/tooltip/props.ts
+++ b/src/lib/components/tooltip/props.ts
@@ -1,5 +1,6 @@
 import { Snippet } from "svelte";
 import { Attachment } from "svelte/attachments";
+import { OptionalModel } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
 export type QTooltipPosition =
@@ -14,46 +15,35 @@ export type QTooltipPosition =
 
 export type QTooltipOffset = { x?: number; y?: number };
 
-export interface QTooltipProps<T extends Element | string> extends HTMLAttributes<HTMLDivElement> {
+export interface QTooltipProps<T extends Element | string>
+  extends OptionalModel<boolean>, HTMLAttributes<HTMLDivElement> {
   /**
    * The target element the tooltip should be attached to. Can be an HTML element or a CSS selector. If not specified, the tooltip will be attached to the nearest Quaff component in the parent tree.
    */
   target?: T;
 
   /**
-   * Defines the show/hide state of the tooltip. By default, the tooltip will be be shown on mouseenter and hidden on mouseleave.
-   * @default false
-   * @bindable
-   */
-  value?: boolean;
-
-  /**
    * Defines the position of the tooltip.
-   * @default "bottom"
    */
   position?: QTooltipPosition;
 
   /**
    * Offset of the tooltip in pixels. Positive values move the tooltip down/right, negative values move the tooltip up/left.
-   * @default { x: 0, y: 0 }
    */
   offset?: QTooltipOffset;
 
   /**
    * Delay in milliseconds before the tooltip appears.
-   * @default 250
    */
   delay?: number;
 
   /**
    * Delay in milliseconds before the tooltip is hidden.
-   * @default 250
    */
   hideDelay?: number;
 
   /**
    * Snippet holding the trigger element/component. Its scope contains a Svelte attachment that should be spread on the trigger element.
-   *
    */
   trigger?: Snippet<[{ [k: symbol]: Attachment<HTMLElement> }]>;
 }

--- a/src/lib/composables/useSize.ts
+++ b/src/lib/composables/useSize.ts
@@ -26,7 +26,11 @@ export function useSize(size: number | string, component?: `q-${string}`) {
   };
 
   return {
-    class: sizeClass,
-    style: sizeStyle(),
+    get class() {
+      return sizeClass;
+    },
+    get style() {
+      return sizeStyle();
+    },
   };
 }

--- a/src/lib/utils/router.ts
+++ b/src/lib/utils/router.ts
@@ -33,7 +33,7 @@ export function getRouterInfo<T extends RouterProps>(props: T) {
       return linkAttributes;
     },
     get linkClass() {
-      return (hasLink && "q-link") || undefined;
+      return hasLink ? "q-link" : undefined;
     },
     get isActive() {
       return isActive;

--- a/src/lib/utils/router.ts
+++ b/src/lib/utils/router.ts
@@ -1,33 +1,42 @@
 import { page } from "$app/state";
+import type { Linkable, WithActiveAttrs } from "./types";
 
-export interface RouterProps {
-  activeClass?: string;
-  disabled?: boolean;
-  href?: string;
-  replace?: boolean;
-  to?: string;
-}
+interface RouterProps extends Linkable, WithActiveAttrs {}
 
 export function isRouteActive(route?: string) {
   if (!route) {
-    return false;
+    return;
   }
 
   return page.url.pathname === route || page.url.pathname.startsWith(`${route}/`);
 }
 
+/**
+ * Provides routing information for a component.
+ *
+ * This includes link attributes, the `q-link` class, as well as whether the component is active due to routing.
+ */
 export function getRouterInfo<T extends RouterProps>(props: T) {
   const hasLink = [props.to, props.href].some((entry) => entry !== undefined);
-  const linkClasses = `${hasLink ? "q-link" : ""} ${props.disabled ? "disabled" : ""}`.trim();
+  const isActive = isRouteActive(props.to || props.href);
 
   const linkAttributes = {
+    "data-sveltekit-reload": props.replace || undefined,
     href: props.to || props.href,
-    "data-sveltekit-reload": props.replace ? true : undefined,
   };
 
   return {
-    hasLink,
-    linkAttributes,
-    linkClasses,
+    get hasLink() {
+      return hasLink;
+    },
+    get linkAttributes() {
+      return linkAttributes;
+    },
+    get linkClass() {
+      return (hasLink && "q-link") || undefined;
+    },
+    get isActive() {
+      return isActive;
+    },
   };
 }

--- a/src/lib/utils/types/base.ts
+++ b/src/lib/utils/types/base.ts
@@ -3,3 +3,9 @@ export type CssUnit = "px" | "%" | "em" | "ex" | "ch" | "rem" | "vw" | "vh" | "v
 export type CssValue = `${number}${CssUnit}`;
 
 export type StringWithSuggestions<T extends string> = T | (string & {});
+
+/**
+ * Utility type used to indicate the default value for a prop.
+ * This is used for decgen to know what the default value is for extended properties.
+ */
+export type WithDefault<T, _D extends T> = T;

--- a/src/lib/utils/types/base.ts
+++ b/src/lib/utils/types/base.ts
@@ -3,9 +3,3 @@ export type CssUnit = "px" | "%" | "em" | "ex" | "ch" | "rem" | "vw" | "vh" | "v
 export type CssValue = `${number}${CssUnit}`;
 
 export type StringWithSuggestions<T extends string> = T | (string & {});
-
-/**
- * Utility type used to indicate the default value for a prop.
- * This is used for decgen to know what the default value is for extended properties.
- */
-export type WithDefault<T, _D extends T> = T;

--- a/src/lib/utils/types/props/content.ts
+++ b/src/lib/utils/types/props/content.ts
@@ -1,0 +1,29 @@
+export interface Labelable {
+  /**
+   * The text to be displayed in the component.
+   * When applicable, will overwrite the children snippet content.
+   */
+  label?: string;
+}
+
+/**
+ * Props to handle `class` and `style` attributes for active components.
+ *
+ */
+export interface WithActiveAttrs {
+  /**
+   * Class string to apply when the component (or its associated route) is active.
+   *
+   * `activeClass` on component groups (e.g. `QList`, `QTabs` etc.) will apply to active components they contain.
+   * `activeClass` on individual components (e.g. `QItem`, `QTab` etc.) will overwrite `activeClass` from their containing group.
+   */
+  activeClass?: string;
+
+  /**
+   * Styles to add when the component (or its associated route) is active.
+   *
+   * `activeStyle` on component groups (e.g. `QList`, `QTabs` etc.) will apply to active components they contain.
+   * `activeStyle` on individual components (e.g. `QItem`, `QTab` etc.) will overwrite `activeStyle` from their containing group.
+   */
+  activeStyle?: string;
+}

--- a/src/lib/utils/types/props/design.ts
+++ b/src/lib/utils/types/props/design.ts
@@ -1,0 +1,59 @@
+import { CssValue } from "../base";
+import { QSize } from "../quaff";
+
+/**
+ * Gives components support for the size property, allowing predefined sizes to be chosen.
+ * 
+ * The type parameter `ToExclude` is used to exclude sizes that are not applicable to the component.
+ 
+ */
+export interface QSizeable<ToExclude extends QSize | undefined = undefined> {
+  /**
+   * Size of the component to choose between multiple predefined sizes.
+   */
+  size?: Exclude<QSize, ToExclude>;
+}
+
+/**
+ * Gives components support for the size property, allowing predefined sizes to be chosen.
+ *
+ * The type parameter `ToExclude` is used to exclude sizes that are not applicable to the component.
+ *
+ * Also supports CSS size values (e.g. "40px", "1rem").
+ * If a number is provided, it will be converted to a px value.
+ */
+export interface CssSizeable {
+  /**
+   * Size of the component using CSS size values (e.g. "40px", "1rem").
+   * If a number is provided, it will be converted to a px value.
+   */
+  size?: CssValue | number;
+}
+
+/**
+ * Gives components support for the size property, allowing predefined sizes to be chosen.
+ *
+ * The type parameter `ToExclude` is used to exclude sizes that are not applicable to the component.
+ *
+ * Also supports CSS size values (e.g. "40px", "1rem").
+ * If a number is provided, it will be converted to a px value.
+ */
+export interface Sizeable<ToExclude extends QSize | undefined = undefined> {
+  /**
+   * Size of the component to choose between multiple predefined sizes.
+   *
+   * Also supports CSS size values (e.g. "40px", "1rem").
+   * If a number is provided, it will be converted to a px value.
+   */
+  size?: Exclude<QSize, ToExclude> | CssValue | number;
+}
+
+/**
+ * Gives the component a border to better separate it from its environment
+ */
+export interface Borderable {
+  /**
+   * Whether the component should have a border.
+   */
+  bordered?: boolean;
+}

--- a/src/lib/utils/types/props/index.ts
+++ b/src/lib/utils/types/props/index.ts
@@ -1,1 +1,4 @@
-export {};
+export * from "./content";
+export * from "./design";
+export * from "./model";
+export * from "./state";

--- a/src/lib/utils/types/props/model.ts
+++ b/src/lib/utils/types/props/model.ts
@@ -1,0 +1,13 @@
+export interface RequiredModel<T> {
+  /**
+   * The bound value of the component.
+   */
+  value: T;
+}
+
+export interface OptionalModel<T> {
+  /**
+   * The bound value of the component.
+   */
+  value?: T;
+}

--- a/src/lib/utils/types/props/state.ts
+++ b/src/lib/utils/types/props/state.ts
@@ -1,0 +1,53 @@
+import { HTMLAnchorAttributes } from "svelte/elements";
+
+export interface Disableable {
+  /**
+   * Puts the component into a disabled state, which prevents user interaction.
+   *
+   * @default false
+   */
+  disabled?: boolean;
+}
+
+export interface Clickable extends Disableable {
+  /**
+   * Disables the ripple effect on click.
+   *
+   * @default false
+   */
+  noRipple?: boolean;
+
+  /**
+   * Sets the ripple effect's color for the component.
+   * If omitted, the ripple will inherit the component's text color.
+   */
+  rippleColor?: string;
+}
+
+export interface Linkable {
+  /**
+   * Makes the component navigational, typically used for links to set the URL or route it should navigate to.
+   */
+  href?: string;
+
+  /**
+   * Makes the component navigational, typically used for links to set the URL or route it should navigate to.
+   *
+   * As it is the same as href, it is recommended to use href instead.
+   */
+  to?: string;
+
+  /**
+   * Replaces the current entry in the browser's history rather than adding a new one.
+   *
+   * This is the same as setting the `data-sveltekit-reload` attribute to "true".
+   *
+   * @default false
+   */
+  replace?: boolean;
+
+  /**
+   * For navigational components only, sets or retrieves the window or frame at which to target content.
+   */
+  target?: HTMLAnchorAttributes["target"];
+}

--- a/src/routes/components/breadcrumbs/+page.svelte
+++ b/src/routes/components/breadcrumbs/+page.svelte
@@ -1,12 +1,12 @@
 <script lang="ts">
-  import { QBreadcrumbsDocs } from "$components/breadcrumbs/docs";
+  import { QBreadcrumbsDocs, QBreadcrumbsElDocs } from "$components/breadcrumbs/docs";
   import { docsCtx } from "$docs/QDocs.svelte";
   import { pageTitle } from "$helpers/pageTitle";
   import { QBreadcrumbs, QBreadcrumbsEl, QCard } from "$lib";
   import { QDocs, QDocsSection } from "$docs";
   import snippets from "./docs.snippets";
 
-  docsCtx.set({ snippets, componentDocs: QBreadcrumbsDocs });
+  docsCtx.set({ snippets, componentDocs: [QBreadcrumbsDocs, QBreadcrumbsElDocs] });
 </script>
 
 <svelte:head>
@@ -77,7 +77,7 @@
         <div class="q-mb-md">
           <QBreadcrumbs>
             {#snippet separator()}
-              <span class="text-red">•••</span>
+              <span class="text-green">•••</span>
             {/snippet}
 
             <QBreadcrumbsEl to="/" label="Home" />
@@ -87,18 +87,29 @@
         </div>
       </QDocsSection>
 
-      <QDocsSection title="Custom Colors">
+      <QDocsSection title="Active Colors, Classes, and Styles">
         {#snippet sectionDescription()}
           <p>
             Customize the active item color and separator color using the <code>activeColor</code>
             and
             <code>separatorColor</code> props. These accept any color from your theme.
           </p>
+          <p>
+            You can also use the <code>activeClass</code> and <code>activeStyle</code> props to customize
+            the active item's appearance using Quaff utility classes and inline styles.
+          </p>
         {/snippet}
         <div class="q-mb-md">
+          <QBreadcrumbs activeColor="error" separatorColor="primary" separator="icon:chevron_right">
+            <QBreadcrumbsEl to="/" label="Home" />
+            <QBreadcrumbsEl to="/components" label="Components" />
+            <QBreadcrumbsEl label="Breadcrumbs" />
+          </QBreadcrumbs>
+        </div>
+        <div class="q-mb-md">
           <QBreadcrumbs
-            activeColor="error-container"
-            separatorColor="green"
+            activeClass="primary q-px-sm"
+            activeStyle="border-radius: 0.25rem"
             separator="icon:chevron_right"
           >
             <QBreadcrumbsEl to="/" label="Home" />
@@ -149,7 +160,8 @@
         {#snippet sectionDescription()}
           <p>
             Adjust the spacing around separators using the <code>gutter</code> prop. Available
-            options are <code>sm</code> (default), <code>md</code>, and <code>lg</code>.
+            options are <code>none</code>, <code>sm</code> (default), <code>md</code>, and
+            <code>lg</code>.
           </p>
         {/snippet}
         <div class="q-mb-md">

--- a/src/routes/components/toolbar/+page.svelte
+++ b/src/routes/components/toolbar/+page.svelte
@@ -15,7 +15,7 @@
 
 <QDocs>
   {#snippet display()}
-    <QToolbar border>
+    <QToolbar bordered>
       <QBtn flat icon="menu" />
       <QToolbarTitle>My Application</QToolbarTitle>
       <QBtn flat icon="search" />
@@ -31,7 +31,7 @@
           headers and footers, it contains navigation icons, titles, and action buttons.
         {/snippet}
 
-        <QToolbar border class="q-mb-md">
+        <QToolbar bordered class="q-mb-md">
           <QBtn flat icon="menu" />
           <QToolbarTitle>Basic Toolbar</QToolbarTitle>
           <QBtn flat icon="search" />
@@ -45,12 +45,12 @@
           shrink when needed to accommodate other toolbar elements.
         {/snippet}
 
-        <QToolbar border class="q-mb-md">
+        <QToolbar bordered class="q-mb-md">
           <QBtn flat icon="arrow_back" />
           <QToolbarTitle>Page Title</QToolbarTitle>
         </QToolbar>
 
-        <QToolbar border class="q-mb-md">
+        <QToolbar bordered class="q-mb-md">
           <QBtn flat icon="menu" />
           <QToolbarTitle shrink>Shrinkable Title</QToolbarTitle>
           <QBtn flat label="Action 1" />
@@ -60,7 +60,7 @@
 
       <QDocsSection title="Appearance Options">
         {#snippet sectionDescription()}
-          Customize the toolbar appearance with props like <code>border</code>,
+          Customize the toolbar appearance with props like <code>bordered</code>,
           <code>elevate</code>, and <code>inset</code>. These control the visual styling and spacing
           of the toolbar.
         {/snippet}
@@ -74,8 +74,8 @@
         </div>
 
         <div class="q-mb-md">
-          <p class="text-caption q-mb-xs">With Border</p>
-          <QToolbar border>
+          <p class="text-caption q-mb-xs">With bordered</p>
+          <QToolbar bordered>
             <QBtn flat icon="menu" />
             <QToolbarTitle>Bordered</QToolbarTitle>
           </QToolbar>
@@ -114,7 +114,7 @@
 
         <div class="q-mb-md">
           <p class="text-caption q-mb-xs">Default Height (64px)</p>
-          <QToolbar border>
+          <QToolbar bordered>
             <QBtn flat icon="menu" />
             <QToolbarTitle>Default Height</QToolbarTitle>
           </QToolbar>
@@ -122,7 +122,7 @@
 
         <div class="q-mb-md">
           <p class="text-caption q-mb-xs">Compact Height (48px)</p>
-          <QToolbar border height={48}>
+          <QToolbar bordered height={48}>
             <QBtn flat icon="menu" />
             <QToolbarTitle>Compact</QToolbarTitle>
           </QToolbar>
@@ -130,7 +130,7 @@
 
         <div class="q-mb-md">
           <p class="text-caption q-mb-xs">Tall Height (80px)</p>
-          <QToolbar border height={80}>
+          <QToolbar bordered height={80}>
             <QBtn flat icon="menu" />
             <QToolbarTitle>Tall</QToolbarTitle>
           </QToolbar>
@@ -144,7 +144,7 @@
 
         <div class="q-mb-md">
           <p class="text-caption q-mb-xs">Navigation Drawer Menu</p>
-          <QToolbar border>
+          <QToolbar bordered>
             <QBtn flat icon="menu" />
             <QToolbarTitle>My App</QToolbarTitle>
           </QToolbar>
@@ -152,7 +152,7 @@
 
         <div class="q-mb-md">
           <p class="text-caption q-mb-xs">Back Navigation</p>
-          <QToolbar border>
+          <QToolbar bordered>
             <QBtn flat icon="arrow_back" />
             <QToolbarTitle>Page Details</QToolbarTitle>
           </QToolbar>
@@ -160,7 +160,7 @@
 
         <div class="q-mb-md">
           <p class="text-caption q-mb-xs">Search Bar</p>
-          <QToolbar border>
+          <QToolbar bordered>
             <QBtn flat icon="arrow_back" />
             <QToolbarTitle>
               <QInput value="how to center a div" dense rounded style="width: 33%;">
@@ -174,7 +174,7 @@
 
         <div class="q-mb-md">
           <p class="text-caption q-mb-xs">Action Buttons</p>
-          <QToolbar border inset>
+          <QToolbar bordered inset>
             <QToolbarTitle class="justify-start">Edit Document</QToolbarTitle>
             <QBtn flat label="Save" />
             <QBtn flat label="Cancel" />


### PR DESCRIPTION
…s and fix some problems

## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Fix some problems with props interface parsing
- Centralize similar props to be shared between multiple components
- Improve `getRouterInfo` to be more focused on links and use it where needed instead of repeating code
- Fix some UI problems
- Allow shared props to have a global default value for docs that can be overwritten by setting a default value inside the `.svelte` component file (e.g. `replace` prop is `false` in docs by default using `@default false` inside the interface. If a component defines `let { replace = true } = $props()`, the doc's default would become `true`)
- Improve some components' API using new shared props

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
