### PR TITLE
fix: escaping and QLinearProgress' aria-valuenow

### DIFF
--- a/src/lib/components/progress/QLinearProgress.svelte
+++ b/src/lib/components/progress/QLinearProgress.svelte
@@ -20,6 +20,7 @@
 
   // #region:    --- Derived values
   const normalized = $derived(value > 1 ? value / 100 : value);
+  const percentage = $derived(normalized * 100);
   const normalizedBuffer = $derived(buffer && buffer > 1 ? buffer / 100 : buffer);
 
   const parsedColor = $derived(useColor(color));
@@ -59,7 +60,7 @@
   role="progressbar"
   aria-valuemin="0"
   aria-valuemax="100"
-  aria-valuenow={indeterminate ? undefined : normalized}
+  aria-valuenow={indeterminate ? undefined : percentage}
   data-quaff
 >
   <div

--- a/src/lib/utils/string.ts
+++ b/src/lib/utils/string.ts
@@ -93,9 +93,9 @@ export function extractImgSrc(prop?: string) {
 
 export function escape(str: string) {
   return str
-    .replace("&", "&amp;")
-    .replace('"', "&quot;")
-    .replace("'", "&#39;")
-    .replace("<", "&lt;")
-    .replace(">", "&gt;");
+    .replaceAll("&", "&amp;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;");
 }


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- escape function now replaces all occurrences
- QLinearProgress: fix aria-valuenow attribute

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
