### PR TITLE
perf: component runtime optimizations

### DIFF
--- a/src/lib/classes/QTheme.svelte.ts
+++ b/src/lib/classes/QTheme.svelte.ts
@@ -39,21 +39,24 @@ class QTheme {
     this.themeColors = prepareThemeColors(this.srcColor);
   }
 
-  private apply() {
+  private apply(colors: Partial<ThemeColors> = this.themeColors) {
     const root = document.documentElement;
     if (root === null) {
       return;
     }
 
     let colorName: keyof ThemeColors;
-    for (colorName in this.themeColors) {
-      root.style.setProperty(`--${colorName}`, this.themeColors[colorName]);
+    for (colorName in colors) {
+      const color = colors[colorName];
+      if (color) {
+        root.style.setProperty(`--${colorName}`, color);
+      }
     }
   }
 
   updateThemeColor(color: keyof ThemeColors, newVal: HexValue) {
     this.themeColors[color] = newVal;
-    this.apply();
+    this.apply({ [color]: newVal });
   }
 
   updateThemeColors(colors: Partial<ThemeColors>) {
@@ -66,7 +69,7 @@ class QTheme {
       }
     }
 
-    this.apply();
+    this.apply(colors);
   }
 
   setTheme(from: string) {

--- a/src/lib/components/drawer/QDrawer.svelte
+++ b/src/lib/components/drawer/QDrawer.svelte
@@ -34,15 +34,15 @@
   let removePointermoveListener: (() => void) | undefined;
   let removePointerupListener: (() => void) | undefined;
   let removePointercancelListener: (() => void) | undefined;
+
+  let isSwiping = false;
+  let startX = 0;
+  let dragOffset = 0;
   // #endregion: --- Non-reactive variables
 
   // #region:    --- Reactive variables
   let drawerEl = $state<HTMLDivElement>();
   let swipeAreaEl = $state<HTMLDivElement>();
-
-  let isSwiping = $state(false);
-  let startX = $state(0);
-  let dragOffset = $state(0);
   // #endregion: --- Reactive variables
 
   // #region:    --- Derived values

--- a/src/lib/components/menu/QMenu.svelte
+++ b/src/lib/components/menu/QMenu.svelte
@@ -31,6 +31,7 @@
   let menuMaxWidth = $state<string | undefined>();
   let menuPosition = $state<"fixed" | "absolute">("fixed");
   let wasMenuOpen = false;
+  let positionFrame: number | undefined;
   // #endregion: --- Reactive variables
 
   // #region:    --- Derived values
@@ -77,13 +78,14 @@
 
     const viewportWidth = innerWidth.current;
     const viewportHeight = innerHeight.current;
-    const syncCurrentPosition = () => syncPosition(viewportWidth, viewportHeight);
+    const syncCurrentPosition = () => schedulePositionSync(viewportWidth, viewportHeight);
 
-    syncCurrentPosition();
+    syncPosition(viewportWidth, viewportHeight);
     const removeWindowScrollListener = on(window, "scroll", syncCurrentPosition, { capture: true });
 
     return () => {
       removeWindowScrollListener();
+      cancelPositionSync();
     };
   });
 
@@ -169,7 +171,7 @@
     }
 
     syncPosition();
-    requestAnimationFrame(() => syncPosition());
+    schedulePositionSync();
   }
 
   function closeMenu() {
@@ -226,6 +228,29 @@
     menuPosition = "fixed";
     menuTop = Math.max(margin, Math.min(top, viewportHeight - measured.height - margin));
     menuLeft = Math.max(margin, Math.min(left, viewportWidth - measuredWidth - margin));
+  }
+
+  function schedulePositionSync(
+    viewportWidth = innerWidth.current,
+    viewportHeight = innerHeight.current
+  ) {
+    if (positionFrame !== undefined) {
+      return;
+    }
+
+    positionFrame = requestAnimationFrame(() => {
+      positionFrame = undefined;
+      syncPosition(viewportWidth, viewportHeight);
+    });
+  }
+
+  function cancelPositionSync() {
+    if (positionFrame === undefined) {
+      return;
+    }
+
+    cancelAnimationFrame(positionFrame);
+    positionFrame = undefined;
   }
 
   function handleDocumentPointerdown(event: PointerEvent) {

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -13,9 +13,10 @@
     getInitialOptionIndex,
     getNextValue,
     getOptionLabel,
+    getOptionValue,
     normalizeOptionIndex,
   } from "./option";
-  import type { QSelectOption, QSelectProps, QSelectValue } from "./props";
+  import type { QSelectOption, QSelectProps } from "./props";
 
   type QSelectEvent<T extends Event> = QEvent<T, HTMLDivElement>;
 
@@ -82,6 +83,13 @@
     getInputValue(currentDisplayValue, searchValue, useInput, isSearching)
   );
 
+  const selectedOptionValues = $derived.by(() => {
+    if (!multiple || !Array.isArray(value)) {
+      return null;
+    }
+
+    return new Set(value.map(getOptionValue).filter((optionValue) => !Number.isNaN(optionValue)));
+  });
   const isOptionSelectedByIndex = $derived(visibleOptions.map(isSelected));
   const activeOptionId = $derived(
     isMenuOpen && focusedOptionIndex >= 0 ? getOptionId(focusedOptionIndex) : undefined
@@ -257,10 +265,11 @@
   }
 
   function isSelected(option: QSelectOption) {
-    const isArray = (val: QSelectValue): val is QSelectOption[] => Array.isArray(val);
-    return multiple
-      ? isArray(value) && value.some((opt) => doValuesMatch(opt, option))
-      : !isArray(value) && doValuesMatch(value, option);
+    if (multiple) {
+      return selectedOptionValues?.has(getOptionValue(option)) ?? false;
+    }
+
+    return !Array.isArray(value) && doValuesMatch(value, option);
   }
 
   function handleOptionMousedown(evt: MouseEvent) {

--- a/src/lib/components/select/filter.ts
+++ b/src/lib/components/select/filter.ts
@@ -1,4 +1,3 @@
-import { getOptionLabel } from "./option";
 import type { QSelectOption, QSelectProps } from "./props";
 
 type QSelectOnFilter = QSelectProps["onFilter"];
@@ -25,9 +24,10 @@ export function getFilteredOptions(
     return options;
   }
 
-  return options.filter((option) =>
-    String(getOptionLabel(option, options)).toLowerCase().includes(query)
-  );
+  return options.filter((option) => {
+    const label = typeof option === "object" && option !== null ? option.label : option;
+    return String(label).toLowerCase().includes(query);
+  });
 }
 
 export function getInputValue(

--- a/src/lib/components/tooltip/QTooltip.svelte
+++ b/src/lib/components/tooltip/QTooltip.svelte
@@ -28,17 +28,13 @@
   let removeTooltipMouseLeaveListener: (() => void) | undefined;
   let removeWindowWheelListener: (() => void) | undefined;
 
+  let tooltipEl: HTMLDivElement | undefined;
+  let realTarget: HTMLElement | undefined;
+  let timerShow: ReturnType<typeof setTimeout> | null = null;
+  let timerHide: ReturnType<typeof setTimeout> | null = null;
+
   const id = $props.id();
   // #endregion: --- Non-reactive variables
-
-  // #region:    --- Reactive variables
-  let tooltipEl = $state<HTMLDivElement>();
-
-  let realTarget = $state<HTMLElement>();
-
-  let timerShow = $state<ReturnType<typeof setTimeout> | null>(null);
-  let timerHide = $state<ReturnType<typeof setTimeout> | null>(null);
-  // #endregion: --- Reactive variables
 
   // #region:    --- Effects
   $effect(() => {

--- a/src/lib/helpers/ripple.ts
+++ b/src/lib/helpers/ripple.ts
@@ -34,43 +34,45 @@ const COLOR_PROPERTY = "--ripple-color";
 const DURATION_PROPERTY = "--ripple-duration";
 
 export function ripple(options: RippleOptions = {}): Attachment<HTMLElement> {
-  const rippleContainer = document.createElement("div");
+  let rippleContainer: HTMLDivElement | undefined;
+  const duration = options.duration && options.duration > 0 ? options.duration : undefined;
 
   function isDisabled(el: HTMLElement, opts: RippleOptions) {
     return opts.disabled || el.hasAttribute("aria-disabled");
   }
 
-  function addClasses(center = false) {
+  function addClasses(container: HTMLDivElement, center = false) {
     const shouldBeCentered = center || options.center;
 
-    rippleContainer.classList.add(EFFECT_CLASS);
+    container.classList.add(EFFECT_CLASS);
 
     if (shouldBeCentered) {
-      rippleContainer.classList.add(CENTER_CLASS);
+      container.classList.add(CENTER_CLASS);
     } else {
-      rippleContainer.classList.remove(CENTER_CLASS);
+      container.classList.remove(CENTER_CLASS);
     }
   }
 
-  function setOptions(el: HTMLElement, opts: RippleOptions) {
-    if (isDisabled(el, opts)) {
-      rippleContainer.remove();
-      return;
+  function getRippleContainer(el: HTMLElement) {
+    if (rippleContainer) {
+      return rippleContainer;
     }
 
+    rippleContainer = document.createElement("div");
     el.appendChild(rippleContainer);
 
-    if (opts.duration && opts.duration < 0) {
-      opts.duration = undefined;
+    if (duration) {
+      rippleContainer.style.setProperty(DURATION_PROPERTY, `${duration}ms`);
     }
 
-    if (opts.duration) {
-      rippleContainer.style.setProperty(DURATION_PROPERTY, `${opts.duration}ms`);
+    if (options.color) {
+      rippleContainer.style.setProperty(
+        COLOR_PROPERTY,
+        `var(--${options.color}, ${options.color})`
+      );
     }
 
-    if (opts.color) {
-      rippleContainer.style.setProperty(COLOR_PROPERTY, `var(--${opts.color}, ${opts.color})`);
-    }
+    return rippleContainer;
   }
 
   function createRipple(
@@ -94,7 +96,8 @@ export function ripple(options: RippleOptions = {}): Attachment<HTMLElement> {
       return;
     }
 
-    addClasses(center);
+    const rippleContainer = getRippleContainer(el);
+    addClasses(rippleContainer, center);
 
     const rect = el.getBoundingClientRect();
 
@@ -127,22 +130,23 @@ export function ripple(options: RippleOptions = {}): Attachment<HTMLElement> {
 
       setTimeout(() => {
         ripple.remove();
-      }, options.duration || 1000);
+      }, duration || 1000);
 
       removeCancelListeners.forEach((removeCancelListener) => removeCancelListener());
     }
   }
 
   return (element: HTMLElement) => {
-    addClasses();
-    setOptions(element, options);
+    if (options.disabled) {
+      return;
+    }
 
     const removeTriggerListeners = TRIGGER_EVENTS.map((event) =>
       on(element, event, (e) => createRipple(element, e), { passive: event === "touchstart" })
     );
 
     return () => {
-      rippleContainer.remove();
+      rippleContainer?.remove();
       removeTriggerListeners.forEach((unlisten) => unlisten());
     };
   };


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Optimize QSelect filtering and selected-option lookups for large option sets.
- Coalesce QMenu scroll-position updates into animation frames.
- Limit partial QTheme updates to the changed CSS variables.
- Lazily create ripple elements and skip setup for explicitly disabled ripples.
- Remove unnecessary reactive state from QDrawer swipe bookkeeping.
- Remove unnecessary reactive state from QTooltip controller bookkeeping.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A