### PR TITLE
fix(css): preserve QField label animation units

### DIFF
--- a/src/lib/plugins/css.ts
+++ b/src/lib/plugins/css.ts
@@ -32,6 +32,7 @@ export function quaffCss(options: QuaffCssOptions = {}): Plugin {
   return {
     name: "quaff:css",
     enforce: "pre",
+    config: cssMinifierConfig,
     configResolved(resolvedConfig) {
       config = resolvedConfig;
     },
@@ -76,6 +77,18 @@ export function quaffCss(options: QuaffCssOptions = {}): Plugin {
     },
   };
 }
+
+export function quaffCssMinifier(): Plugin {
+  return {
+    name: "quaff:css-minifier",
+    config: cssMinifierConfig,
+  };
+}
+
+const cssMinifierConfig: Plugin["config"] = {
+  order: "post",
+  handler: () => ({ build: { cssMinify: "esbuild" } }),
+};
 
 async function createCssModule(root: string, options: QuaffCssOptions) {
   const css = await collectUsedCss(root, options);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,9 +2,10 @@ import path from "path";
 import { sveltekit } from "@sveltejs/kit/vite";
 import { defineConfig } from "vitest/config";
 import docgenPlugin from "./src/dev/docgenPlugin";
+import { quaffCssMinifier } from "./src/lib/plugins/css";
 
 export default defineConfig({
-  plugins: [docgenPlugin(), sveltekit()],
+  plugins: [docgenPlugin(), sveltekit(), quaffCssMinifier()],
   test: {
     include: ["src/**/*.{test,spec}.{js,ts}"],
   },


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- preserve QField label animation units

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
