### PR TITLE
refactor: implement custom Shiki themes for Quaff

### DIFF
--- a/src/docs/QApi.svelte
+++ b/src/docs/QApi.svelte
@@ -20,6 +20,7 @@
     ParsedPropertyFlags,
     type ParsedType,
   } from "$docgen/props/parsePropsInterface/defs";
+  import { quaffTsHighlighter } from "$internal/shikiTheme";
   import { docsCtx } from "./QDocs.svelte";
 
   type TabableDocsKey = Exclude<
@@ -45,7 +46,7 @@
 
     const generation = ++tooltipGeneration;
     cleanupTooltips();
-    attachTooltips(generation);
+    attachTooltips(generation, Quaff.darkMode.isActive);
 
     return cleanupTooltips;
   });
@@ -327,7 +328,7 @@
     tooltipTeardowns = [];
   }
 
-  async function attachTooltips(generation: number) {
+  async function attachTooltips(generation: number, darkMode: boolean) {
     await tick();
 
     if (generation !== tooltipGeneration) {
@@ -381,11 +382,9 @@
 
       const type = getType(typeName) || "/* No definition found */";
 
-      const { codeToHtml } = await import("shiki");
-
-      const html = await codeToHtml(type, {
+      const html = quaffTsHighlighter.codeToHtml(type, {
         lang: "typescript",
-        theme: Quaff.darkMode.isActive ? "github-dark-default" : "github-light-default",
+        theme: darkMode ? "quaff-dark" : "quaff-light",
         transformers: [
           {
             pre(node) {

--- a/src/lib/components/codeBlock/QCodeBlock.svelte
+++ b/src/lib/components/codeBlock/QCodeBlock.svelte
@@ -33,17 +33,19 @@
   // #endregion: --- Reactive variables
 
   // #region:    --- Derived values
-  const resolvedTheme = $derived(
-    typeof theme === "string" && theme !== "quaff"
-      ? theme
-      : Quaff.darkMode.isActive
-        ? theme === "quaff"
-          ? "quaff-dark"
-          : theme.dark
-        : theme === "quaff"
-          ? "quaff-light"
-          : theme.light
-  );
+  const resolvedTheme = $derived.by(() => {
+    if (typeof theme === "string" && theme !== "quaff") {
+      return theme;
+    }
+
+    const suffix = Quaff.darkMode.isActive ? "dark" : "light";
+
+    if (theme === "quaff") {
+      return `quaff-${suffix}` as const;
+    }
+
+    return theme[suffix];
+  });
   // #endregion: --- Derived values
 
   // #region:    --- Effects

--- a/src/lib/components/codeBlock/QCodeBlock.svelte
+++ b/src/lib/components/codeBlock/QCodeBlock.svelte
@@ -1,14 +1,16 @@
 <script lang="ts">
+  import { onMount } from "svelte";
   import Quaff from "$classes/Quaff.svelte";
   import QBtn from "$components/button/QBtn.svelte";
   import { copy, escape } from "$utils";
+  import { createQuaffHighlighter } from "$internal/shikiTheme";
+  import type { BundledTheme, Highlighter } from "shiki";
   import type { QCodeBlockProps } from "./props";
 
   // #region:    --- Props
   let {
     language,
-    lightTheme = "github-light-default",
-    darkTheme = "github-dark-default",
+    theme = "quaff",
     code = "/* No code found */",
     title,
     copiable,
@@ -23,16 +25,46 @@
   } as const;
 
   // #region:    --- Reactive variables
+  let highlighter = $state<Highlighter>();
   let copyStatus = $state<keyof typeof copyButtonStates>("base");
   let html = $state("");
 
   const copyButton = $derived(copyButtonStates[copyStatus]);
   // #endregion: --- Reactive variables
 
+  // #region:    --- Derived values
+  const resolvedTheme = $derived(
+    typeof theme === "string" && theme !== "quaff"
+      ? theme
+      : Quaff.darkMode.isActive
+        ? theme === "quaff"
+          ? "quaff-dark"
+          : theme.dark
+        : theme === "quaff"
+          ? "quaff-light"
+          : theme.light
+  );
+  // #endregion: --- Derived values
+
   // #region:    --- Effects
+  onMount(async () => {
+    const themeList: BundledTheme[] = [];
+
+    if (typeof theme === "string" && theme !== "quaff") {
+      themeList.push(theme);
+    } else if (typeof theme === "object") {
+      themeList.push(...Object.values(theme));
+    }
+
+    highlighter = await createQuaffHighlighter([language], themeList);
+  });
+
   $effect(() => {
-    const theme = Quaff.darkMode.isActive ? darkTheme : lightTheme;
-    void updateHtml(code, language, theme);
+    if (!highlighter) {
+      return;
+    }
+
+    void updateHtml(code, language, resolvedTheme);
   });
   // #endregion: --- Effects
 
@@ -53,14 +85,16 @@
   async function updateHtml(
     source: string,
     language: QCodeBlockProps["language"],
-    theme: typeof lightTheme
+    resolvedTheme: BundledTheme | `quaff-${"light" | "dark"}`
   ) {
-    try {
-      const { codeToHtml } = await import("shiki");
+    if (!highlighter) {
+      return;
+    }
 
-      html = await codeToHtml(source, {
+    try {
+      html = highlighter.codeToHtml(source, {
         lang: language,
-        theme,
+        theme: resolvedTheme,
       });
     } catch (error) {
       console.error("Error while highlighting code with Shiki", error);

--- a/src/lib/components/codeBlock/props.ts
+++ b/src/lib/components/codeBlock/props.ts
@@ -10,12 +10,7 @@ export interface QCodeBlockProps extends HTMLAttributes<HTMLDivElement> {
   /**
    * Theme to use for highlighting for light mode.
    */
-  lightTheme?: BundledTheme;
-
-  /**
-   * Theme to use for highlighting for dark mode.
-   */
-  darkTheme?: BundledTheme;
+  theme?: "quaff" | BundledTheme | { light: BundledTheme; dark: BundledTheme };
 
   /**
    * Code to highlight.

--- a/src/lib/internal/shikiTheme.ts
+++ b/src/lib/internal/shikiTheme.ts
@@ -1,0 +1,131 @@
+import { createHighlighter, type ThemeRegistration } from "shiki";
+
+function createQuaffShikiTheme(
+  name: string,
+  settings: NonNullable<ThemeRegistration["settings"]>
+): ThemeRegistration {
+  return {
+    name,
+    colors: {
+      "editor.background": "var(--surface-container)",
+      "editor.foreground": "var(--on-surface)",
+    },
+    settings: [
+      {
+        scope: [
+          "comment",
+          "punctuation.definition.comment",
+          "string.comment",
+          "markup.ignored",
+          "markup.untracked",
+        ],
+        settings: {
+          foreground: "var(--on-surface-variant)",
+        },
+      },
+      {
+        scope: [
+          "constant",
+          "support",
+          "entity",
+          "entity.name.constant",
+          "markup.inline.raw",
+          "meta.property-name",
+          "meta.module-reference",
+          "meta.diff.header",
+          "meta.separator",
+          "meta.output",
+          "string-variable",
+          "support.constant",
+          "support.variable",
+          "variable.other.constant",
+          "variable.other.enummember",
+          "variable.language",
+        ],
+        settings: {
+          foreground: "var(--tertiary)",
+        },
+      },
+      {
+        scope: ["markup.heading", "markup.heading entity.name"],
+        settings: {
+          fontStyle: "bold",
+          foreground: "var(--tertiary)",
+        },
+      },
+      {
+        scope: [
+          "entity.name",
+          "meta.export.default",
+          "meta.definition.variable",
+          "variable",
+          "punctuation.definition.list.begin.markdown",
+        ],
+        settings: {
+          foreground: "var(--primary)",
+        },
+      },
+      {
+        scope: [
+          "constant.other.placeholder",
+          "constant.character",
+          "keyword",
+          "storage",
+          "storage.type",
+          "punctuation.section.embedded",
+        ],
+        settings: {
+          foreground: "var(--error)",
+        },
+      },
+      {
+        scope: [
+          "string",
+          "string punctuation.section.embedded source",
+          "source.regexp",
+          "string.regexp",
+          "string.regexp.character-class",
+          "string.regexp constant.character.escape",
+          "string.regexp source.ruby.embedded",
+          "string.regexp string.regexp.arbitrary-repitition",
+          "constant.other.reference.link",
+          "string.other.link",
+        ],
+        settings: {
+          foreground: "var(--secondary)",
+        },
+      },
+      ...settings,
+    ],
+  };
+}
+
+const quaffShikiLightTheme = createQuaffShikiTheme("quaff-light", [
+  {
+    scope: ["entity.name.tag", "support.class.component"],
+    settings: {
+      foreground: "var(--color-green-8)",
+    },
+  },
+]);
+
+const quaffShikiDarkTheme = createQuaffShikiTheme("quaff-dark", [
+  {
+    scope: ["entity.name.tag", "support.class.component"],
+    settings: {
+      foreground: "var(--color-green-5)",
+    },
+  },
+]);
+
+export async function createQuaffHighlighter(
+  langs: Parameters<typeof createHighlighter>[0]["langs"],
+  themes: Parameters<typeof createHighlighter>[0]["themes"] = []
+) {
+  return await createHighlighter({
+    langs,
+    themes: [quaffShikiLightTheme, quaffShikiDarkTheme, ...themes],
+  });
+}
+
+export const quaffTsHighlighter = await createQuaffHighlighter(["typescript"]);


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## What's new?

> List the changes

- Implement a custom Shiki theme for Quaff
- Change `QApi` and `QCodeBlock` to support the new theme

> NB: now Shiki is not imported dynamically, but that shouldn't be a problem now we have proper tree shaking (Shiki won't be imported if `QCodeBlock` is not)

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

Closes #242 
