### PR TITLE
fix: avoid shiki warning by configuring a global highlighter in quaff config

### DIFF
--- a/src/docs/QApi.svelte
+++ b/src/docs/QApi.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   /* eslint-disable svelte/no-at-html-tags */
   import { createRawSnippet, mount, tick, unmount } from "svelte";
+  import { codeToHtml } from "shiki";
   import {
     QCard,
     QCardSection,
@@ -20,7 +21,7 @@
     ParsedPropertyFlags,
     type ParsedType,
   } from "$docgen/props/parsePropsInterface/defs";
-  import { quaffTsHighlighter } from "$internal/shikiTheme";
+  import { quaffShikiDarkTheme, quaffShikiLightTheme } from "$internal/shikiTheme";
   import { docsCtx } from "./QDocs.svelte";
 
   type TabableDocsKey = Exclude<
@@ -382,9 +383,9 @@
 
       const type = getType(typeName) || "/* No definition found */";
 
-      const html = quaffTsHighlighter.codeToHtml(type, {
+      const html = await codeToHtml(type, {
         lang: "typescript",
-        theme: darkMode ? "quaff-dark" : "quaff-light",
+        theme: darkMode ? quaffShikiDarkTheme : quaffShikiLightTheme,
         transformers: [
           {
             pre(node) {

--- a/src/lib/components/codeBlock/QCodeBlock.svelte
+++ b/src/lib/components/codeBlock/QCodeBlock.svelte
@@ -1,10 +1,9 @@
 <script lang="ts">
-  import { onMount } from "svelte";
+  import { codeToHtml, type BundledTheme, type ThemeRegistration } from "shiki";
   import Quaff from "$classes/Quaff.svelte";
   import QBtn from "$components/button/QBtn.svelte";
   import { copy, escape } from "$utils";
-  import { createQuaffHighlighter } from "$internal/shikiTheme";
-  import type { BundledTheme, Highlighter } from "shiki";
+  import { quaffShikiDarkTheme, quaffShikiLightTheme } from "$internal/shikiTheme";
   import type { QCodeBlockProps } from "./props";
 
   // #region:    --- Props
@@ -25,7 +24,6 @@
   } as const;
 
   // #region:    --- Reactive variables
-  let highlighter = $state<Highlighter>();
   let copyStatus = $state<keyof typeof copyButtonStates>("base");
   let html = $state("");
 
@@ -41,7 +39,7 @@
     const suffix = Quaff.darkMode.isActive ? "dark" : "light";
 
     if (theme === "quaff") {
-      return `quaff-${suffix}` as const;
+      return suffix === "dark" ? quaffShikiDarkTheme : quaffShikiLightTheme;
     }
 
     return theme[suffix];
@@ -49,23 +47,7 @@
   // #endregion: --- Derived values
 
   // #region:    --- Effects
-  onMount(async () => {
-    const themeList: BundledTheme[] = [];
-
-    if (typeof theme === "string" && theme !== "quaff") {
-      themeList.push(theme);
-    } else if (typeof theme === "object") {
-      themeList.push(...Object.values(theme));
-    }
-
-    highlighter = await createQuaffHighlighter([language], themeList);
-  });
-
   $effect(() => {
-    if (!highlighter) {
-      return;
-    }
-
     void updateHtml(code, language, resolvedTheme);
   });
   // #endregion: --- Effects
@@ -87,14 +69,10 @@
   async function updateHtml(
     source: string,
     language: QCodeBlockProps["language"],
-    resolvedTheme: BundledTheme | `quaff-${"light" | "dark"}`
+    resolvedTheme: BundledTheme | ThemeRegistration
   ) {
-    if (!highlighter) {
-      return;
-    }
-
     try {
-      html = highlighter.codeToHtml(source, {
+      html = await codeToHtml(source, {
         lang: language,
         theme: resolvedTheme,
       });

--- a/src/lib/internal/shikiTheme.ts
+++ b/src/lib/internal/shikiTheme.ts
@@ -1,4 +1,4 @@
-import { createHighlighter, type ThemeRegistration } from "shiki";
+import type { ThemeRegistration } from "shiki";
 
 function createQuaffShikiTheme(
   name: string,
@@ -100,7 +100,7 @@ function createQuaffShikiTheme(
   };
 }
 
-const quaffShikiLightTheme = createQuaffShikiTheme("quaff-light", [
+export const quaffShikiLightTheme = createQuaffShikiTheme("quaff-light", [
   {
     scope: ["entity.name.tag", "support.class.component"],
     settings: {
@@ -109,7 +109,7 @@ const quaffShikiLightTheme = createQuaffShikiTheme("quaff-light", [
   },
 ]);
 
-const quaffShikiDarkTheme = createQuaffShikiTheme("quaff-dark", [
+export const quaffShikiDarkTheme = createQuaffShikiTheme("quaff-dark", [
   {
     scope: ["entity.name.tag", "support.class.component"],
     settings: {
@@ -117,15 +117,3 @@ const quaffShikiDarkTheme = createQuaffShikiTheme("quaff-dark", [
     },
   },
 ]);
-
-export async function createQuaffHighlighter(
-  langs: Parameters<typeof createHighlighter>[0]["langs"],
-  themes: Parameters<typeof createHighlighter>[0]["themes"] = []
-) {
-  return await createHighlighter({
-    langs,
-    themes: [quaffShikiLightTheme, quaffShikiDarkTheme, ...themes],
-  });
-}
-
-export const quaffTsHighlighter = await createQuaffHighlighter(["typescript"]);


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- add `shikiHighlighter` to Quaff's config to have a global highlighter usable for all `QCodeBlock` instances which suppresses the warning

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
