### PR TITLE
fix: fix inconsistencies in some components' documentation

### DIFF
--- a/src/lib/components/separator/QSeparator.scss
+++ b/src/lib/components/separator/QSeparator.scss
@@ -31,7 +31,7 @@
   flex: 1 1 auto;
 
   &--vertical {
-    width: var(--q-separator--size, 0.0625rem);
+    width: var(--q-separator-size, 0.0625rem);
 
     @each $space, $val in variables.$spaces {
       @if $space != "none" and $space != "auto" {
@@ -43,7 +43,7 @@
   }
 
   &:not(&--vertical) {
-    height: var(--q-separator--size, 0.0625rem);
+    height: var(--q-separator-size, 0.0625rem);
 
     @each $space, $val in variables.$spaces {
       @if $space != "auto" {

--- a/src/lib/components/separator/QSeparator.svelte
+++ b/src/lib/components/separator/QSeparator.svelte
@@ -17,7 +17,8 @@
 
   // #region:    --- Derived values
   const orientation = $derived(vertical ? "vertical" : "horizontal");
-  const qSize = $derived(useSize(spacing, "q-separator__spacing"));
+  const qSpacing = $derived(useSize(spacing, "q-separator__spacing"));
+  const qSize = $derived(size ? useSize(size) : undefined);
   const parsedColor = $derived(useColor(color));
   // #endregion: --- Derived values
 
@@ -25,7 +26,7 @@
     bemClasses: {
       vertical,
     },
-    classes: [qSize.class],
+    classes: [qSpacing.class],
   });
   Q.classes("q-separator__wrapper", {
     bemClasses: {
@@ -36,7 +37,13 @@
   });
 </script>
 
-<div {...props} class="q-separator__wrapper" data-quaff style:--q-separator-color={parsedColor}>
+<div
+  {...props}
+  class="q-separator__wrapper"
+  data-quaff
+  style:--q-separator-color={parsedColor}
+  style:--q-separator-size={qSize?.style}
+>
   {#if text}
     {#if (vertical && textAlign !== "top") || (!vertical && textAlign !== "left")}
       {@render hr()}
@@ -53,5 +60,5 @@
 </div>
 
 {#snippet hr()}
-  <hr class="q-separator" style:--q-separator-size={size} aria-orientation={orientation} />
+  <hr class="q-separator" aria-orientation={orientation} />
 {/snippet}

--- a/src/lib/components/separator/props.ts
+++ b/src/lib/components/separator/props.ts
@@ -1,7 +1,7 @@
-import type { QSize } from "$utils";
+import type { CssSizeable, QSize } from "$utils";
 import type { HTMLAttributes } from "svelte/elements";
 
-export interface QSeparatorVerticalProps {
+export interface QSeparatorVerticalProps extends CssSizeable {
   /**
    * Spacing around the separator.
    */
@@ -23,11 +23,6 @@ export interface QSeparatorVerticalProps {
   color?: string;
 
   /**
-   * Custom size (thickness) of the separator line.
-   */
-  size?: string;
-
-  /**
    * Text to display. Its position on the separator is determined by the textAlign prop.
    */
   text?: string;
@@ -38,7 +33,7 @@ export interface QSeparatorVerticalProps {
   textAlign?: "top" | "middle" | "bottom";
 }
 
-export interface QSeparatorHorizontalProps {
+export interface QSeparatorHorizontalProps extends CssSizeable {
   /**
    * Spacing around the separator.
    */
@@ -58,11 +53,6 @@ export interface QSeparatorHorizontalProps {
    * Color of the separator line.
    */
   color?: string;
-
-  /**
-   * Custom size (thickness) of the separator line.
-   */
-  size?: string;
 
   /**
    * Text to display. Its position on the separator is determined by the textAlign prop.

--- a/src/routes/components/footer/+page.svelte
+++ b/src/routes/components/footer/+page.svelte
@@ -96,7 +96,7 @@
       <QDocsSection title="Custom Height Footer">
         {#snippet sectionDescription()}
           You can specify the height of the footer using the <code>height</code> prop. As of now, the
-          height can only be set in pixels (passing a number). The default height is 64px.
+          height can only be set in pixels (passing a number). The default height is 80px.
         {/snippet}
 
         <QLayout style="border: 1px solid var(--outline-variant)">

--- a/src/routes/components/icon/+page.svelte
+++ b/src/routes/components/icon/+page.svelte
@@ -128,11 +128,15 @@
           <ol class="q-pl-lg q-my-sm">
             <li>Pass SVG content directly via the default slot.</li>
             <li>
-              Pass an SVG string via the <code>svg</code> prop (Note: Current component
-              implementation might need adjustment to render the <code>svg</code> prop content
-              correctly using <code>@html</code>).
+              Pass an SVG string via the <code>svg</code> prop.
             </li>
           </ol>
+
+          <p class="text-bold">
+            Note: use the <code>svg</code> prop with extreme caution as it uses the
+            <code>@html</code> directive, which can lead to XSS attacks if not used carefully. Use it
+            only if you trust the source of the SVG content.
+          </p>
         {/snippet}
         <!-- Example SVG content -->
         {@const exampleSvg = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M12 2C6.48 2 2 6.48 2 12s4.48 10 10 10 10-4.48 10-10S17.52 2 12 2zm0 18c-4.41 0-8-3.59-8-8s3.59-8 8-8 8 3.59 8 8-3.59 8-8 8zm-1-13h2v6h-2zm0 8h2v2h-2z"/></svg>`}

--- a/src/routes/components/radio/+page.svelte
+++ b/src/routes/components/radio/+page.svelte
@@ -94,8 +94,8 @@
 
       <QDocsSection title="Two-way Binding">
         {#snippet sectionDescription()}
-          QRadio supports Svelte's two-way binding with the <code>bind</code>selected` directive.
-          This makes it easy to track and update the selected value in your component's state.
+          QRadio supports Svelte's two-way binding with the <code>bind:selected</code> directive. This
+          makes it easy to track and update the selected value in your component's state.
         {/snippet}
 
         <div class="q-ma-sm flex column q-gap-md">

--- a/src/routes/components/select/+page.svelte
+++ b/src/routes/components/select/+page.svelte
@@ -375,8 +375,8 @@
 
       <QDocsSection title="Two-way Binding">
         {#snippet sectionDescription()}
-          QSelect supports Svelte's two-way binding with the <code>bind</code>value directive. This
-          makes it easy to sync the select's state with your component's variables.
+          QSelect supports Svelte's two-way binding with the <code>bind:value</code> directive. This makes
+          it easy to sync the select's state with your component's variables.
         {/snippet}
 
         <div class="row q-gutter-md q-ma-sm">

--- a/src/routes/components/separator/+page.svelte
+++ b/src/routes/components/separator/+page.svelte
@@ -116,17 +116,17 @@
         </div>
       </QDocsSection>
 
-      <QDocsSection title="Custom Size (Thickness) - Not supported yet">
+      <QDocsSection title="Custom Size (Thickness)">
         {#snippet sectionDescription()}
           Control the thickness of the separator line with the <code>size</code> prop. This accepts any
-          valid CSS size value.
+          valid CSS size value. If a number is provided it will be treated as px.
         {/snippet}
 
         <div class="q-my-md">
           <QSeparator text="Default Size" />
-          <QSeparator text="2px Thick" size="2px" class="q-my-md" />
+          <QSeparator text="2px Thick (number)" size={2} class="q-my-md" />
           <QSeparator text="3px Thick" size="3px" class="q-my-md" />
-          <QSeparator text="5px Thick" size="5px" class="q-my-md" />
+          <QSeparator text="0.25rem Thick" size="0.25rem" class="q-my-md" />
         </div>
       </QDocsSection>
 


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Fix `bind:value` and `bind:selected` directives inside `QSelect` and `QRadio` docs
- Add actual support for `QSeparator`'s `size` prop
- Fix wrong default value for `height` inside `QFooter` docs
- Remove dev note for `QIcon`'s SVG section and add a warning note about `svg` prop and XSS attacks

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A
