### PR TITLE
fix: fix various bugs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,8 @@
 # Quaff Agent Notes
 
 - Keep changes small and component-local. Do not stage unrelated work such as experimental components unless the task explicitly asks for it.
+- Keep every diff justified by the requested behavior: fix a reproduced bug, implement an explicitly requested feature, or make the code clearly simpler or faster. Avoid speculative changes and unrelated cleanup.
+- Add a blank line before and after control-flow blocks such as `if`, `for`, `while`, `switch`, and `try`/`catch` when they sit next to other statements. Omit it when the block is first or last in its enclosing scope, and keep paired clauses such as `else`, `catch`, and `finally` together.
 - Quaff is Svelte 5 only. Use runes-style component code (`$props`, `$state`, `$derived`, snippets) and avoid adding legacy Svelte 4 patterns.
 - Use `bun run check` and `bun run build` for full validation. `bun run format` currently also sees untracked local files, so verify the worktree before trusting a format failure.
 - Internal library code must not import components through `$lib` or the public package barrel. Use direct aliases such as `$components`, `$classes`, `$utils`, and `$internal`.

--- a/plugins/class-preprocessor/script.ts
+++ b/plugins/class-preprocessor/script.ts
@@ -36,24 +36,24 @@ export function prepareScript(instance: Script, source: string, namespace: strin
     const { start, end } = expression as Node<"SimpleCallExpression">;
 
     if (expression.arguments.length !== 2) {
-      throw new Error("The ${namespace}.classes function takes exactly 2 arguments");
+      throw new Error(`The ${namespace}.classes function takes exactly 2 arguments`);
     }
 
     const [component, options] = expression.arguments;
 
     if (component.type !== "Literal") {
       throw new Error(
-        "The ${namespace}.classes 1st argument should be a Literal containing the name of the component"
+        `The ${namespace}.classes 1st argument should be a Literal containing the name of the component`
       );
     }
 
     if (options.type !== "ObjectExpression") {
-      throw new Error("The ${namespace}.classes 2nd argument should be an object");
+      throw new Error(`The ${namespace}.classes 2nd argument should be an object`);
     }
 
     if (options.properties.some((prop) => prop.type === "SpreadElement")) {
       throw new Error(
-        "The ${namespace}.classes 2nd argument doesn't take SpreadElements as a property"
+        `The ${namespace}.classes 2nd argument doesn't take SpreadElements as a property`
       );
     }
 

--- a/src/lib/classes/QScrollObserver.svelte.ts
+++ b/src/lib/classes/QScrollObserver.svelte.ts
@@ -69,14 +69,20 @@ export default class QScrollObserver {
     this.direction = horizontal ? "right" : "down";
 
     onMount(() => {
-      let parsedTarget = elFromSelector(target ?? null);
+      const resolvedTarget =
+        target === null || target === undefined ? window : elFromSelector(target);
 
-      if (parsedTarget === null) {
+      if (resolvedTarget === null) {
         console.warn(`The given target (${target}) is null, observing window instead`);
-        parsedTarget = window;
       }
 
+      const parsedTarget = resolvedTarget instanceof HTMLElement ? resolvedTarget : window;
+
       this.target = parsedTarget;
+      const initialPosition = this.getScrollPosition(parsedTarget);
+      this.lastScroll = initialPosition;
+      this.position = initialPosition;
+      this.inflectionPoint = initialPosition;
 
       this.removeScrollListener = on(parsedTarget, "scroll", this.handler, SCROLL_LISTENER_OPTIONS);
 
@@ -131,6 +137,11 @@ export default class QScrollObserver {
     this.position = newScrollPosition;
     this.delta = newScrollPosition - this.lastScroll;
 
+    if (this.delta === 0) {
+      this.changedDirection = false;
+      return;
+    }
+
     const newDirection: Direction =
       this.delta > 0 ? (this.horizontal ? "right" : "down") : this.horizontal ? "left" : "up";
 
@@ -165,7 +176,7 @@ export default class QScrollObserver {
     this.removeScrollListener = null;
 
     this.target = null;
-    this.direction = "down";
+    this.direction = this.horizontal ? "right" : "down";
     this.changedDirection = false;
     this.delta = 0;
     this.inflectionPoint = 0;

--- a/src/lib/components/button/QBtn.svelte
+++ b/src/lib/components/button/QBtn.svelte
@@ -155,7 +155,7 @@
   style:--q-btn-icon-size={iconSize}
   style:--ripple-color={color && useColor(color)}
   href={disabled ? undefined : routerInfo.linkAttributes.href}
-  data-sveltekit-reload={routerInfo.linkAttributes["data-sveltekit-reload"]}
+  data-sveltekit-replacestate={routerInfo.linkAttributes["data-sveltekit-replacestate"]}
   disabled={computedTag === "button" ? disabled : undefined}
   role={computedTag === "button" ? undefined : "button"}
   aria-disabled={disabled || undefined}

--- a/src/lib/components/button/QBtn.svelte
+++ b/src/lib/components/button/QBtn.svelte
@@ -109,25 +109,31 @@
       return;
     }
 
+    onclick?.(event as Parameters<NonNullable<QBtnProps["onclick"]>>[0]);
+
+    if (event.defaultPrevented) {
+      return;
+    }
+
     if (isToggle) {
       selected = !selected;
     }
-
-    onclick?.(event as Parameters<NonNullable<QBtnProps["onclick"]>>[0]);
   }
 
   function handleKeydown(event: ButtonEvent<KeyboardEvent>) {
-    if (event.key === "Escape") {
-      event.currentTarget.blur();
-    }
-
     if (disabled) {
       return;
     }
 
     onkeydown?.(event as Parameters<NonNullable<QBtnProps["onkeydown"]>>[0]);
 
-    if (isActivationKey(event)) {
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    if (event.key === "Escape") {
+      event.currentTarget.blur();
+    } else if (isActivationKey(event)) {
       event.preventDefault();
       event.currentTarget.click();
     }

--- a/src/lib/components/chip/QChip.svelte
+++ b/src/lib/components/chip/QChip.svelte
@@ -42,6 +42,7 @@
   const hasElevation = $derived(elevated && kind !== "input");
 
   const avatar = $derived(extractImgSrc(icon));
+  const trailingImage = $derived(extractImgSrc(trailing));
   const iconSize = $derived(size === "sm" ? 18 : size === "md" ? 22.5 : 27);
   // #endregion: --- Derived values
 
@@ -213,7 +214,8 @@
     {#if trailing}
       <QIcon
         class="q-chip__trailing-icon"
-        name={trailing}
+        name={trailingImage ? undefined : (trailing as MaterialSymbol)}
+        img={trailingImage}
         size={iconSize}
         onclick={(e) => handleClick(e, true)}
       />

--- a/src/lib/components/chip/QChip.svelte
+++ b/src/lib/components/chip/QChip.svelte
@@ -71,6 +71,18 @@
       return;
     }
 
+    e.stopPropagation();
+
+    if (iconClick) {
+      onTrailingIconClick?.(e);
+    } else {
+      props.onclick?.(e as QEvent<MouseEvent, HTMLDivElement>);
+    }
+
+    if (e.defaultPrevented) {
+      return;
+    }
+
     if (kind === "input" && iconClick) {
       inputSelected = false;
     } else if (kind === "filter" && !iconClick) {
@@ -78,13 +90,6 @@
     } else if (kind === "input" && !iconClick && value !== undefined) {
       inputSelected = false;
       editing = true;
-    }
-
-    e.stopPropagation();
-    if (iconClick) {
-      onTrailingIconClick?.(e);
-    } else {
-      props.onclick?.(e as QEvent<MouseEvent, HTMLDivElement>);
     }
 
     if (editing) {
@@ -95,6 +100,16 @@
   }
 
   async function onkeydown(e: KeyboardEvent) {
+    if (disabled) {
+      return;
+    }
+
+    props.onkeydown?.(e as QEvent<KeyboardEvent, HTMLDivElement>);
+
+    if (e.defaultPrevented) {
+      return;
+    }
+
     if (kind === "input" && e.key === "Backspace") {
       e.preventDefault();
 

--- a/src/lib/components/dialog/QDialog.svelte
+++ b/src/lib/components/dialog/QDialog.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
   import { on } from "svelte/events";
+  import type { QEvent } from "$utils";
   import type { QDialogProps } from "./props";
+
+  type QDialogEvent<T extends Event> = QEvent<T, HTMLDialogElement>;
 
   // #region:    --- Props
   let {
@@ -10,6 +13,9 @@
     fullscreen = false,
     persistent = false,
     children,
+    onclick,
+    onkeydown,
+    oncancel,
     ...props
   }: QDialogProps = $props();
   // #endregion: --- Props
@@ -77,18 +83,39 @@
     }
   }
 
-  function handleClickInside(e: MouseEvent) {
+  function handleClickInside(e: QDialogEvent<MouseEvent>) {
+    onclick?.(e);
+
+    if (e.defaultPrevented) {
+      return;
+    }
+
     e.stopPropagation();
   }
 
-  function onkeydown(e: KeyboardEvent) {
-    if (e.key === "Escape") {
+  function handleKeydown(e: QDialogEvent<KeyboardEvent>) {
+    onkeydown?.(e);
+
+    if (!e.defaultPrevented && e.key === "Escape") {
+      tryCancel(e);
+    }
+  }
+
+  function handleCancel(e: QDialogEvent<Event>) {
+    oncancel?.(e);
+
+    if (!e.defaultPrevented) {
       tryCancel(e);
     }
   }
 
   function tryCancel(e: Event) {
+    if (e.defaultPrevented) {
+      return;
+    }
+
     const target = e.target;
+
     if (target instanceof Element && target.closest("[data-quaff-overlay]")) {
       return;
     }
@@ -118,8 +145,8 @@
   {...props}
   class="q-dialog"
   onclick={handleClickInside}
-  oncancel={tryCancel}
-  {onkeydown}
+  oncancel={handleCancel}
+  onkeydown={handleKeydown}
   aria-hidden={!value || undefined}
   data-quaff
 >

--- a/src/lib/components/drawer/QDrawer.svelte
+++ b/src/lib/components/drawer/QDrawer.svelte
@@ -63,7 +63,7 @@
   });
 
   const isModal = $derived(overlay || isBelowBreakpoint);
-  const canHideOnClickOutside = $derived((value && !persistent) || isModal);
+  const canHideOnClickOutside = $derived(value && !persistent);
   const hideOnRouteChange = $derived(!persistent || isModal);
   const canSwipe = $derived(!noSwipe && isBelowBreakpoint);
 
@@ -369,10 +369,12 @@
   <button
     type="button"
     tabindex="-1"
-    aria-label="Close drawer"
+    aria-label={persistent ? undefined : "Close drawer"}
+    aria-hidden={persistent || undefined}
+    disabled={persistent}
     class="q-drawer__scrim"
     class:q-drawer__scrim--active={value}
-    onclick={hide}
+    onclick={persistent ? undefined : hide}
   ></button>
 {/if}
 

--- a/src/lib/components/expansion-item/QExpansionItem.svelte
+++ b/src/lib/components/expansion-item/QExpansionItem.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
   import { slide } from "svelte/transition";
-  import { goto } from "$app/navigation";
   import QBtn from "$components/button/QBtn.svelte";
   import QIcon from "$components/icon/QIcon.svelte";
   import QItem from "$components/list/QItem.svelte";
@@ -24,12 +23,16 @@
     expandIconToggle = false,
     to,
     href,
+    replace,
+    target,
     name,
     noRotateExpandIcon = false,
     disabled = false,
     noRipple = false,
     summary,
     children,
+    onclick: onClick,
+    onkeydown: onKeydown,
     onExpandIconClick,
     ...props
   }: QExpansionItemProps = $props();
@@ -130,7 +133,11 @@
       return;
     }
 
-    props.onclick?.(e);
+    onClick?.(e);
+
+    if (!e.defaultPrevented && expandIconToggle && !to && !href) {
+      e.preventDefault();
+    }
   }
 
   function onIconClick(e: QEvent<MouseEvent, HTMLElement>) {
@@ -146,7 +153,13 @@
     onExpandIconClick?.(e);
   }
 
-  function onkeydown(e: KeyboardEvent) {
+  function onkeydown(e: QEvent<KeyboardEvent, HTMLElement>) {
+    onKeydown?.(e);
+
+    if (e.defaultPrevented) {
+      return;
+    }
+
     if (disabled) {
       preventAndStop(e);
       return;
@@ -158,12 +171,6 @@
     }
 
     if (!isActivationKey(e)) {
-      return;
-    }
-
-    if (to || href) {
-      preventAndStop(e);
-      goto((to || href) as string);
       return;
     }
 
@@ -245,6 +252,8 @@
         {dense}
         {to}
         {href}
+        {replace}
+        {target}
         {disabled}
         noRipple={expandIconToggle || noRipple}
         clickable={!expandIconToggle}
@@ -258,6 +267,8 @@
         {dense}
         {to}
         {href}
+        {replace}
+        {target}
         {disabled}
         noRipple={expandIconToggle || noRipple}
         clickable={!expandIconToggle}

--- a/src/lib/components/expansion-item/props.ts
+++ b/src/lib/components/expansion-item/props.ts
@@ -1,6 +1,6 @@
 import { MaterialSymbol } from "material-symbols";
 import { Snippet } from "svelte";
-import { HTMLDetailsAttributes, MouseEventHandler } from "svelte/elements";
+import { HTMLDetailsAttributes, KeyboardEventHandler, MouseEventHandler } from "svelte/elements";
 import { Disableable, Labelable, Linkable, OptionalModel } from "$utils";
 
 export interface QExpansionItemProps
@@ -97,4 +97,9 @@ export interface QExpansionItemProps
    * Event triggered when the expansion item is clicked.
    */
   onclick?: MouseEventHandler<HTMLElement>;
+
+  /**
+   * Event triggered when a key is pressed on the expansion item header.
+   */
+  onkeydown?: KeyboardEventHandler<HTMLElement>;
 }

--- a/src/lib/components/footer/QFooter.svelte
+++ b/src/lib/components/footer/QFooter.svelte
@@ -28,14 +28,14 @@
   // #endregion: --- Reactive variables
 
   // #region:    --- Derived values
-  const revealObserver = useRevealScrollObserver("footer", uid, () => reveal);
+  const revealObserver = useRevealScrollObserver("footer", uid, () => reveal && value);
   const revealScroll = $derived(revealObserver.scroll);
 
   const offset = $derived(revealScroll ? revealScroll.position + height : undefined);
 
   // Collapse the footer `${revealOffset}px` above the bottom of layout content when scrolling up
   const collapsed = $derived(
-    reveal && revealScroll?.direction === "up" && offset! + revealOffset < contentScrollHeight
+    !value || (revealScroll?.direction === "up" && offset! + revealOffset < contentScrollHeight)
   );
 
   const leftOffset = $derived(footerContext.view.charAt(8) === "l");

--- a/src/lib/components/icon/props.ts
+++ b/src/lib/components/icon/props.ts
@@ -15,7 +15,7 @@ export interface QIconProps extends Sizeable, HTMLAttributes<HTMLElement> {
   /**
    * The name of the Material Symbols icon.
    */
-  name?: MaterialSymbol | `img:${string}`;
+  name?: MaterialSymbol;
 
   /**
    * Determines whether the icon should be filled.

--- a/src/lib/components/menu/QMenu.svelte
+++ b/src/lib/components/menu/QMenu.svelte
@@ -4,7 +4,7 @@
   import { innerHeight, innerWidth } from "svelte/reactivity/window";
   import { browser } from "$app/environment";
   import { quaffConfig } from "$internal/quaffConfig";
-  import { doesOverlayUsePopover, getOverlayPortalTarget, usePortal } from "$utils";
+  import { doesOverlayUsePopover, getOverlayPortalTarget, usePortal, type QEvent } from "$utils";
   import type { QMenuAnchor, QMenuProps } from "./props";
 
   // #region:    --- Props
@@ -19,6 +19,7 @@
     autoClose = true,
     children,
     class: userClass,
+    onclick,
     ...props
   }: QMenuProps = $props();
   // #endregion: --- Props
@@ -105,9 +106,7 @@
         capture: true,
       }
     );
-    const removeDocumentKeydownListener = on(document, "keydown", handleDocumentKeydown, {
-      capture: true,
-    });
+    const removeDocumentKeydownListener = on(document, "keydown", handleDocumentKeydown);
 
     return () => {
       removeDocumentPointerdownListener();
@@ -270,7 +269,7 @@
   }
 
   function handleDocumentKeydown(event: KeyboardEvent) {
-    if (!value || event.key !== "Escape") {
+    if (!value || event.defaultPrevented || event.key !== "Escape") {
       return;
     }
 
@@ -279,8 +278,10 @@
     hide();
   }
 
-  function handleMenuClick() {
-    if (autoClose) {
+  function handleMenuClick(event: QEvent<MouseEvent, HTMLDivElement>) {
+    onclick?.(event);
+
+    if (!event.defaultPrevented && autoClose) {
       hide();
     }
   }

--- a/src/lib/components/select/QSelect.svelte
+++ b/src/lib/components/select/QSelect.svelte
@@ -45,6 +45,10 @@
     append,
     after,
     value = $bindable(),
+    "aria-label": ariaLabel,
+    onblur,
+    onfocus,
+    onkeydown,
     ...props
   }: QSelectProps = $props();
   // #endregion: --- Props
@@ -136,16 +140,18 @@
 
   function handleFocus(e: QSelectEvent<FocusEvent>) {
     isFocused = true;
-    props.onfocus?.(e);
+    onfocus?.(e);
   }
 
   function handleBlur(e: QSelectEvent<FocusEvent>) {
     isFocused = false;
-    props.onblur?.(e);
+    onblur?.(e);
   }
 
   function handleKeydown(e: QSelectEvent<KeyboardEvent>) {
-    if (disabled) {
+    onkeydown?.(e);
+
+    if (e.defaultPrevented || disabled) {
       return;
     }
 
@@ -182,8 +188,6 @@
     } else if (e.code === "Tab") {
       hideMenu();
     }
-
-    props.onkeydown?.(e);
   }
 
   function handleInput(e: Event) {
@@ -355,7 +359,7 @@
         aria-controls={listboxId}
         aria-expanded={isMenuOpen}
         aria-haspopup="listbox"
-        aria-label={label}
+        aria-label={ariaLabel ?? label}
         aria-activedescendant={activeOptionId}
         aria-readonly={useInput ? undefined : "true"}
         onfocus={handleFocus}

--- a/src/lib/components/switch/QSwitch.svelte
+++ b/src/lib/components/switch/QSwitch.svelte
@@ -34,25 +34,29 @@
 
   // #region:    --- Functions
   function onclick(event: QSwitchEvent<MouseEvent>) {
-    event.preventDefault();
     if (disabled) {
       return;
     }
 
     props.onclick?.(event);
 
+    if (event.defaultPrevented) {
+      return;
+    }
+
+    event.preventDefault();
     qSwitchInput.focus();
     toggle();
   }
 
   function onkeydown(event: QSwitchEvent<KeyboardEvent>) {
-    if (disabled || !isActivationKey(event)) {
+    if (disabled) {
       return;
     }
 
     props.onkeydown?.(event);
 
-    if (event.defaultPrevented) {
+    if (event.defaultPrevented || !isActivationKey(event)) {
       return;
     }
 

--- a/src/lib/components/table/QTable.svelte
+++ b/src/lib/components/table/QTable.svelte
@@ -184,6 +184,7 @@
       options={rowsPerPageOptions}
       bind:value={rowsPerPage}
       disabled={rowsPerPageOptions.length <= 1}
+      aria-label="Records per page"
     />
     {numberFrom}-{numberTo}&nbsp;of&nbsp;{rows.length}
     {#if lastPage > 1}
@@ -192,6 +193,7 @@
         size="sm"
         variant="flat"
         disabled={page === 1}
+        aria-label="Previous page"
         onclick={() => page--}
       />
       <QBtn
@@ -199,6 +201,7 @@
         size="sm"
         variant="flat"
         disabled={page === lastPage}
+        aria-label="Next page"
         onclick={() => page++}
       />
     {/if}

--- a/src/lib/components/table/props.ts
+++ b/src/lib/components/table/props.ts
@@ -6,7 +6,7 @@ export type QTableColumn = {
   name: string;
   label: string;
   align?: "left" | "center" | "right";
-  field: string | ((row: QTableRow) => string);
+  field: string | ((row: QTableRow) => string | number);
   format?: (val: string) => string;
   sortable?: boolean;
   sort?: (a: string, b: string) => number;
@@ -17,7 +17,7 @@ export type QTableRow = {
 };
 
 export type QTableSort = {
-  columnField: string | ((row: QTableRow) => string);
+  columnField: QTableColumn["field"];
   type: "asc" | "desc";
 } | null;
 

--- a/src/lib/components/tabs/QTab.svelte
+++ b/src/lib/components/tabs/QTab.svelte
@@ -58,6 +58,10 @@
   function onkeydown(e: QTabEvent<KeyboardEvent>) {
     props.onkeydown?.(e);
 
+    if (e.defaultPrevented) {
+      return;
+    }
+
     if (isActivationKey(e)) {
       e.preventDefault();
       return qTab.click();

--- a/src/lib/components/tabs/QTabs.svelte
+++ b/src/lib/components/tabs/QTabs.svelte
@@ -35,7 +35,6 @@
 
   // #region:    --- Non-reactive variables
   let qTabs: HTMLElement;
-  let tabList: HTMLElement[] = [];
   // #endregion: --- Non-reactive variables
 
   // #region:    --- Reactive variables
@@ -55,10 +54,6 @@
   // #endregion: --- Context
 
   // #region:    --- Effects
-  $effect(() => {
-    tabList = Array.from(qTabs.querySelectorAll(".q-tab"));
-  });
-
   $effect.pre(() => {
     if (value === undefined) {
       return;
@@ -89,12 +84,16 @@
     value = req;
   }
 
+  function getTabs() {
+    return Array.from(qTabs?.querySelectorAll<HTMLElement>(".q-tab") ?? []);
+  }
+
   function getRequestingTab(requestingTabName: string) {
-    return tabList.find((tab) => tab.dataset.qTabName === requestingTabName) ?? null;
+    return getTabs().find((tab) => tab.dataset.qTabName === requestingTabName) ?? null;
   }
 
   function getActiveTab() {
-    return tabList.find((tab) => tab.getAttribute("aria-selected") === "true") ?? null;
+    return getTabs().find((tab) => tab.getAttribute("aria-selected") === "true") ?? null;
   }
 
   function handleFocusout(e: FocusEvent & { currentTarget: HTMLElement }) {

--- a/src/lib/composables/useAlign.ts
+++ b/src/lib/composables/useAlign.ts
@@ -39,7 +39,16 @@ export function useAlign(align: UseAlignOptions = "top left") {
     .split(" ")
     .map((entry) => {
       const val = alignMap[entry as keyof typeof alignMap];
-      return val ? `justify-${val}` : false;
+
+      if (val) {
+        return `justify-${val}`;
+      }
+
+      return {
+        top: "items-start",
+        middle: "items-center",
+        bottom: "items-end",
+      }[entry];
     })
     .filter((entry) => typeof entry === "string");
 

--- a/src/lib/composables/useRouterLink.ts
+++ b/src/lib/composables/useRouterLink.ts
@@ -33,7 +33,7 @@ export function useRouterLink<T extends UseRouterLinkProps>(props: T) {
 
   const linkAttributes = {
     href: props.to || props.href,
-    "data-sveltkit-reload": props.replace ? "" : undefined,
+    "data-sveltekit-replacestate": props.replace || undefined,
   };
 
   return {

--- a/src/lib/utils/colors.ts
+++ b/src/lib/utils/colors.ts
@@ -211,10 +211,13 @@ class QColors {
         "Invalid HEX value. It should follow the format #xxxxxx or #xxx where x is a hexadecimal digit."
       );
     }
-    const result = /^#?([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(hex);
-    return result
-      ? [parseInt(result[1], 16), parseInt(result[2], 16), parseInt(result[3], 16)]
-      : [];
+
+    const normalized =
+      hex.length === 4
+        ? hex.replace(/./g, (character, index) => (index ? character + character : character))
+        : hex;
+    const result = /^#([a-f\d]{2})([a-f\d]{2})([a-f\d]{2})$/i.exec(normalized)!;
+    return result.slice(1).map((value) => parseInt(value, 16));
   }
 
   static rgbToHsl(r: string | number, g: string | number, b: string | number): number[] {
@@ -296,9 +299,7 @@ class QColors {
   }
 
   static hexToHsl(hex: HexValue): { h: number; s: number; l: number } {
-    const r = parseInt(hex.slice(1, 3), 16) / 255;
-    const g = parseInt(hex.slice(3, 5), 16) / 255;
-    const b = parseInt(hex.slice(5, 7), 16) / 255;
+    const [r, g, b] = QColors.hexToRgb(hex).map((value) => value / 255);
 
     const max = Math.max(r, g, b),
       min = Math.min(r, g, b);

--- a/src/lib/utils/router.ts
+++ b/src/lib/utils/router.ts
@@ -24,7 +24,7 @@ export function getRouterInfo<T extends RouterProps>(props: T) {
   const isActive = isRouteActive(resolvedHref);
 
   const linkAttributes = {
-    "data-sveltekit-reload": props.replace || undefined,
+    "data-sveltekit-replacestate": props.replace || undefined,
     href: resolvedHref,
   };
 

--- a/src/lib/utils/types/props/state.ts
+++ b/src/lib/utils/types/props/state.ts
@@ -40,7 +40,7 @@ export interface Linkable {
   /**
    * Replaces the current entry in the browser's history rather than adding a new one.
    *
-   * This is the same as setting the `data-sveltekit-reload` attribute to "true".
+   * This is the same as setting the `data-sveltekit-replacestate` attribute to "true".
    *
    * @default false
    */

--- a/src/routes/components/expansion-item/+page.svelte
+++ b/src/routes/components/expansion-item/+page.svelte
@@ -156,6 +156,7 @@
             caption="Opens in new tab"
             icon="link"
             href="https://example.com"
+            target="_blank"
             expandIconToggle
           >
             <p>This demonstrates using an external link with expand icon toggle functionality.</p>


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [x] Documentation
- [ ] Code style update
- [ ] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

A bunch of AI assorted and validated (GPT 5.6 Sol Ultra) fixes.

- **router: apply replace-state navigation**  
  The `replace` prop added the reload attribute instead of the replace-state attribute. The old version reloaded the page, while the fixed version replaces the current history entry.

- **preprocessor: interpolate class namespace errors**  
  Preprocessor errors displayed the literal text `${namespace}`. They now show the actual namespace that caused the error.

- **QScrollObserver: initialize observed scroll state**  
  An observer mounted at scroll position 200 incorrectly started at zero. Its first upward movement was reported as downward; it now starts from the real position and reports the correct direction and delta.

- **QBtn: respect prevented interactions**  
  Calling `preventDefault()` in a button handler did not stop toggle behavior. Consumer handlers now run first, so canceled interactions no longer change the button state.

- **QChip: preserve consumer interaction handlers**  
  Chips changed state before consumer click and keyboard handlers could cancel the interaction. The handlers now run first and prevented interactions leave the chip unchanged.

- **QDialog: preserve consumer dismissal handlers**  
  QDialog replaced consumer click, keyboard, and cancel handlers with its internal handlers. These handlers are now called, and preventing Escape keeps the dialog open while normal outside clicks still close it.

- **QDrawer: keep persistent modal drawers open**  
  Persistent drawers could still close through the modal scrim. The scrim can no longer dismiss a persistent drawer and is removed from keyboard interaction.

- **QExpansionItem: preserve link and toggle behavior**  
  Link options such as `target` were not forwarded, and internal navigation overrode native link behavior. Link attributes now work normally, and prevented keyboard events no longer toggle the item.

- **QFooter: remove hidden footer layout space**  
  A hidden footer could still reserve its height in the layout. Hiding it now also removes that unused space.

- **QIcon: support image icon names**  
  Supported `img:` icon names were rendered as plain text. They now produce an image element using the extracted source.

- **QMenu: preserve consumer dismissal handling**  
  Menu click handlers could not prevent automatic closing, and Escape was handled before child elements could cancel it. Prevented click and Escape events now keep the menu open.

- **QSelect: forward field interaction attributes**  
  Field attributes such as `aria-label` were not applied to the actual select input, and keyboard behavior ran before consumer handlers. Attributes now reach the input and prevented keyboard events stop internal handling.

- **QSwitch: respect prevented interactions**  
  QSwitch toggled even when its click or keyboard handler canceled the event. Prevented interactions now leave its value unchanged.

- **QTable: label pagination controls**  
  Pagination controls had no accessible names. The rows-per-page select and navigation buttons now have clear labels.

- **QTable: support numeric field resolvers**  
  QTable rows allow numbers, but field resolver functions were typed to return only strings. Numeric resolver results are now accepted consistently.

- **QTab: respect prevented keyboard events**  
  Preventing a keyboard event did not stop tab activation. QTab now checks the canceled state before activating the tab.

- **QTabs: discover dynamic tab elements**  
  The cached tab list did not update when tabs were added after mounting. QTabs now reads the current tab elements when it needs them, allowing dynamic tabs to work.

- **useAlign: apply vertical alignments**  
  Values such as `top`, `middle`, and `bottom` were accepted but produced no vertical alignment classes. They now map to the corresponding cross-axis alignment classes.

- **QColors: support short hex conversion**  
  QColors accepted short hex values such as `#abc`, but converted them to empty or invalid results. Short values are now expanded and converted correctly.

- **agents: require focused and readable changes**  
  The contributor guidance now requires every diff to have a clear reason. It also documents the expected blank-line style around control-flow blocks.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

N/A