### PR TITLE
feat: add Material 3 navbar and navigation items

### DIFF
--- a/src/lib/components/footer/QFooter.scss
+++ b/src/lib/components/footer/QFooter.scss
@@ -6,7 +6,7 @@
   position: absolute;
   top: auto;
   right: 0;
-  bottom: 0;
+  bottom: var(--navbar-height, 0);
   left: 0;
 
   @include mixins.layoutBarDisplay;

--- a/src/lib/components/footer/QFooter.svelte
+++ b/src/lib/components/footer/QFooter.svelte
@@ -54,10 +54,21 @@
 
   // #region:    --- Lifecycle
   onMount(() => {
-    // Calculating the layout content's height
-    const content = document.querySelector(`.q-footer--${uid} ~ .q-layout__content`);
+    const content = footerEl?.parentElement?.querySelector<HTMLElement>(
+      ":scope > .q-layout__content"
+    );
+    const updateContentScrollHeight = () => {
+      contentScrollHeight = content
+        ? content.scrollHeight - content.clientHeight + (collapsed ? height : 0)
+        : 0;
+    };
+    const contentResizeObserver = new ResizeObserver(updateContentScrollHeight);
 
-    contentScrollHeight = content ? content.scrollHeight - content.clientHeight : 0;
+    updateContentScrollHeight();
+
+    if (content) {
+      contentResizeObserver.observe(content);
+    }
 
     setTimeout(() => {
       if (footerEl) {
@@ -66,6 +77,8 @@
     }, 100);
 
     return () => {
+      contentResizeObserver.disconnect();
+
       footerCtx.updateEntries({
         height: 0,
         collapsed: false,

--- a/src/lib/components/index.ts
+++ b/src/lib/components/index.ts
@@ -29,6 +29,8 @@ import QItem from "./list/QItem.svelte";
 import QItemSection from "./list/QItemSection.svelte";
 import QLinearProgress from "./progress/QLinearProgress.svelte";
 import QMenu from "./menu/QMenu.svelte";
+import QNavbar from "./navbar/QNavbar.svelte";
+import QNavItem from "./navbar/QNavItem.svelte";
 import QRadio from "./radio/QRadio.svelte";
 import QRailbar from "./railbar/QRailbar.svelte";
 import QSeparator from "./separator/QSeparator.svelte";
@@ -71,6 +73,8 @@ export {
   QItemSection,
   QLinearProgress,
   QMenu,
+  QNavbar,
+  QNavItem,
   QRadio,
   QRailbar,
   QSeparator,

--- a/src/lib/components/layout/QLayout.scss
+++ b/src/lib/components/layout/QLayout.scss
@@ -19,6 +19,7 @@
 
 .q-layout > .q-railbar {
   position: absolute;
+  bottom: var(--navbar-height, 0);
 
   &.q-railbar--offset-top {
     // Put the railbar under the header to avoid hiding its box-shadow
@@ -32,7 +33,15 @@
   }
 }
 
+.q-layout > .q-navbar {
+  position: absolute;
+}
+
 .q-layout > .q-drawer {
+  &:not(.q-drawer--overlay) {
+    bottom: var(--navbar-height, 0);
+  }
+
   &.q-drawer--offset-top:not(.q-drawer--overlay) {
     // Put the drawer under the header to avoid hiding its box-shadow
     z-index: 2;
@@ -76,7 +85,7 @@
   border-top-right-radius: 0;
 }
 
-.q-layout > .q-footer ~ .q-layout__content {
+.q-layout > :is(.q-footer, .q-navbar) ~ .q-layout__content {
   border-bottom-left-radius: 0;
   border-bottom-right-radius: 0;
 }

--- a/src/lib/components/layout/QLayout.svelte
+++ b/src/lib/components/layout/QLayout.svelte
@@ -18,8 +18,14 @@
     ready: boolean;
   }
 
+  interface NavbarContext {
+    height: number;
+    ready: boolean;
+  }
+
   export const headerCtx = QContext<AppbarContext>("QHeader");
   export const footerCtx = QContext<AppbarContext>("QFooter");
+  export const navbarCtx = QContext<NavbarContext>("QNavbar");
 
   export const leftRailbarCtx = QContext<DrawerContext>("QRailbarLeft");
   export const rightRailbarCtx = QContext<DrawerContext>("QRailbarRight");
@@ -38,6 +44,7 @@
     drawerRight,
     header,
     footer,
+    navbar,
     onscroll,
     onresize,
     children,
@@ -57,6 +64,10 @@
   const footerInfo = $state({
     height: 0,
     collapsed: false,
+    ready: false,
+  });
+  const navbarInfo = $state({
+    height: 0,
     ready: false,
   });
   const leftRailbarInfo = $state({
@@ -83,14 +94,16 @@
 
   // #region:    --- Derived values
   const topOffset = $derived(!header || headerInfo.collapsed ? 0 : headerInfo.height);
-  const bottomOffset = $derived(!footer || footerInfo.collapsed ? 0 : footerInfo.height);
+  const footerOffset = $derived(!footer || footerInfo.collapsed ? 0 : footerInfo.height);
+  const navbarOffset = $derived(!navbar || !navbarInfo.ready ? 0 : navbarInfo.height);
+  const bottomOffset = $derived(footerOffset + navbarOffset);
   const leftOffset = $derived(handleDrawerCtx(leftRailbarInfo) + handleDrawerCtx(leftDrawerInfo));
   const rightOffset = $derived(
     handleDrawerCtx(rightRailbarInfo) + handleDrawerCtx(rightDrawerInfo)
   );
 
   const contentMargin = $derived(
-    `${header ? topOffset : 0}px ${rightOffset}px ${footer ? bottomOffset : 0}px ${leftOffset}px`
+    `${header ? topOffset : 0}px ${rightOffset}px ${bottomOffset}px ${leftOffset}px`
   );
 
   const isReady = $derived(
@@ -99,7 +112,8 @@
       sideBarReady("railbar", "left") &&
       sideBarReady("railbar", "right") &&
       sideBarReady("drawer", "left") &&
-      sideBarReady("drawer", "right")
+      sideBarReady("drawer", "right") &&
+      navbarReady()
   );
   // #endregion: --- Derived values
 
@@ -115,6 +129,10 @@
     height: footerInfo.height,
     collapsed: footerInfo.collapsed,
     ready: footerInfo.ready,
+  });
+  navbarCtx.set({
+    height: navbarInfo.height,
+    ready: navbarInfo.ready,
   });
 
   leftRailbarCtx.set({
@@ -183,6 +201,12 @@
       barReady[barType] || (layoutEl && !layoutEl.querySelector(`:scope > .q-${barType}--${side}`))
     );
   }
+
+  function navbarReady() {
+    return (
+      !navbar || navbarInfo.ready || (layoutEl && !layoutEl.querySelector(":scope > .q-navbar"))
+    );
+  }
   // #endregion: --- Functions
 
   Q.classes("q-layout", {
@@ -201,6 +225,7 @@
   style:--right-drawer-width={`${drawerRight ? rightDrawerInfo.width : 0}px`}
   style:--left-railbar-width={`${railbarLeft ? leftRailbarInfo.width : 0}px`}
   style:--right-railbar-width={`${railbarRight ? rightRailbarInfo.width : 0}px`}
+  style:--navbar-height={`${navbarOffset}px`}
   style:--offset-top={`${topOffset}px`}
   style:--offset-right={`${rightOffset}px`}
   style:--offset-bottom={`${bottomOffset}px`}
@@ -214,11 +239,13 @@
   {@render drawerRight?.()}
   {@render header?.()}
   {@render footer?.()}
+  {@render navbar?.()}
 
   <ContextResetter
     keys={[
       headerCtx.symbol,
       footerCtx.symbol,
+      navbarCtx.symbol,
       leftRailbarCtx.symbol,
       rightRailbarCtx.symbol,
       leftDrawerCtx.symbol,

--- a/src/lib/components/layout/docs.ts
+++ b/src/lib/components/layout/docs.ts
@@ -10,7 +10,7 @@ import {
 export const QLayoutDocs: QComponentDocs = {
   name: "QLayout",
   description:
-    "The QLayout component is designed to be the skeleton of the entire page, with navigational elements such as header, railbars, drawers and footer. This component is not mandatory but it really helps structure the page.",
+    "The QLayout component is designed to be the skeleton of the entire page, with navigational elements such as a header, railbars, drawers, a navbar, and a footer. This component is not mandatory but it helps structure the page.",
   docs: {
     generics: QLayoutDocsGenerics,
     domAttributesConstraint: QLayoutDocsDomAttributesConstraint,

--- a/src/lib/components/layout/props.ts
+++ b/src/lib/components/layout/props.ts
@@ -6,13 +6,13 @@ export type QLayoutViewOptions = `${"l"|"h"}${"h"|"H"}${"r"|"h"} ${"l"|"L"}${"p"
 
 export interface QLayoutProps extends HTMLAttributes<HTMLDivElement> {
   /**
-   * The layout view configuration, which defines how layout components (header, railbars, drawers, footer) should be displayed on screen.
-   * Controls how layout components (header, railbars, drawers, footer) are displayed on screen.
+   * The layout view configuration, which defines how layout components (header, railbars, drawers, and footer) should be displayed on screen.
+   * The navbar always occupies the bottom edge of the layout.
    */
   view?: QLayoutViewOptions;
 
   /**
-   * Main area of the layout where the content will be displayed, meaning everything besides the layout components (header, railbars, drawers, footer).
+   * Main area of the layout where the content will be displayed, meaning everything besides the layout components (header, railbars, drawers, footer, and navbar).
    * It overrides the default children snippet.
    */
   content?: Snippet;
@@ -46,6 +46,11 @@ export interface QLayoutProps extends HTMLAttributes<HTMLDivElement> {
    * The footer of the layout.
    */
   footer?: Snippet;
+
+  /**
+   * The navigation bar at the bottom of the layout.
+   */
+  navbar?: Snippet;
 }
 
 export type QLayoutEvents = "resize" | "scroll" | "scrollHeight";

--- a/src/lib/components/navbar/QNavItem.scss
+++ b/src/lib/components/navbar/QNavItem.scss
@@ -1,0 +1,257 @@
+@use "$css/disabled";
+@use "$css/mixins";
+@use "$css/variables";
+
+.q-nav-item {
+  position: relative;
+  isolation: isolate;
+  box-sizing: border-box;
+  display: grid;
+  grid-template-columns: minmax(0, 1fr);
+  place-items: center;
+  flex: 1 1 0;
+
+  min-width: 0;
+  min-height: 4rem;
+  padding: 0.375rem 0;
+
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  outline: 0;
+  background: transparent;
+  color: var(--on-surface-variant);
+  --q-nav-item-state-layer-color: var(--on-secondary-container);
+  --ripple-color: var(--q-nav-item-state-layer-color);
+  font: inherit;
+  text-align: center;
+  text-decoration: none;
+  cursor: pointer;
+  user-select: none;
+  -webkit-tap-highlight-color: transparent;
+
+  &__target {
+    position: relative;
+    display: grid;
+    grid-template-rows: 2rem minmax(1rem, auto);
+    place-items: center;
+    justify-self: stretch;
+    gap: 0.25rem;
+
+    min-height: 3.25rem;
+
+    &::before,
+    &::after {
+      content: "";
+      position: absolute;
+      inset: 0 auto auto 50%;
+      width: 3.5rem;
+      height: 2rem;
+      border-radius: 2rem;
+      translate: -50%;
+      pointer-events: none;
+    }
+
+    &::before {
+      z-index: 4;
+      outline-offset: -0.1875rem;
+    }
+
+    &::after {
+      z-index: 1;
+      background-color: var(--q-nav-item-state-layer-color);
+      opacity: 0;
+    }
+  }
+
+  &__indicator {
+    z-index: 0;
+    position: absolute;
+    inset: 0 auto auto 50%;
+    width: 3.5rem;
+    height: 2rem;
+    border-radius: 2rem;
+    background-color: var(--q-nav-item-active-indicator-color, var(--secondary-container));
+    opacity: 0;
+    transform: scaleX(0);
+    translate: -50%;
+    transition: variables.$speed2 cubic-bezier(0.2, 0, 0, 1);
+    transition-property: transform, opacity;
+    pointer-events: none;
+  }
+
+  &__icon {
+    z-index: 2;
+    position: relative;
+    display: inline-flex;
+    grid-row: 1;
+    align-items: center;
+    justify-content: center;
+    width: 1.5rem;
+    height: 1.5rem;
+    font-size: 1.5rem;
+    line-height: 1;
+
+    & > .q-icon {
+      transition: font-variation-settings variables.$speed2 cubic-bezier(0.2, 0, 0, 1);
+    }
+  }
+
+  &__label {
+    z-index: 2;
+    grid-row: 2;
+    min-width: 0;
+    white-space: normal;
+
+    @include mixins.typography("label-medium");
+  }
+
+  &__badge {
+    z-index: 3;
+    position: absolute;
+    inset-block-start: -0.125rem;
+    inset-inline-start: 0.75rem;
+    box-sizing: border-box;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+
+    min-width: 1rem;
+    max-width: 2.125rem;
+    height: 1rem;
+    padding-inline: 0.25rem;
+
+    overflow: hidden;
+    border-radius: 1rem;
+    background-color: var(--error);
+    color: var(--on-error);
+    white-space: nowrap;
+    pointer-events: none;
+
+    @include mixins.typography("label-small");
+
+    &:empty {
+      inset-block-start: 0;
+      inset-inline-start: 1.125rem;
+      min-width: 0.375rem;
+      width: 0.375rem;
+      height: 0.375rem;
+      padding: 0;
+    }
+  }
+
+  &__target > .q-ripple__effect {
+    z-index: 1;
+    inset: 0 auto auto 50%;
+    width: 3.5rem;
+    height: 2rem;
+    border-radius: 2rem;
+    translate: -50%;
+  }
+
+  &:hover:not([aria-disabled="true"]) &__target::after {
+    opacity: 0.08;
+  }
+
+  &:focus-visible:not([aria-disabled="true"]) &__target::after,
+  &--no-ripple:active:not([aria-disabled="true"]) &__target::after {
+    opacity: 0.1;
+  }
+
+  &:focus-visible:not([aria-disabled="true"]) &__target::before {
+    outline: 0.1875rem solid var(--secondary);
+  }
+
+  &.q-nav-item--active {
+    color: var(--secondary);
+
+    & .q-nav-item__indicator {
+      opacity: 1;
+      transform: scaleX(1);
+    }
+
+    & .q-nav-item__icon {
+      color: var(--on-secondary-container);
+    }
+  }
+
+  &[aria-disabled="true"] {
+    @include disabled.base();
+
+    & .q-nav-item__icon {
+      color: inherit;
+    }
+  }
+}
+
+.q-navbar--horizontal > .q-nav-item {
+  flex: 0 1 auto;
+  min-width: 5rem;
+  padding-block: 0.75rem;
+
+  & > .q-nav-item__target {
+    display: flex;
+    justify-self: center;
+    min-height: 2.5rem;
+    padding-inline: 1rem;
+
+    &::before,
+    &::after {
+      inset: 0;
+      width: auto;
+      height: auto;
+      translate: none;
+    }
+  }
+
+  & .q-nav-item__indicator {
+    inset: 0;
+    width: auto;
+    height: auto;
+    translate: none;
+  }
+
+  & .q-nav-item__badge {
+    inset-inline: auto -0.25rem;
+
+    &:empty {
+      inset-inline-end: 0;
+    }
+  }
+
+  & > .q-nav-item__target > .q-ripple__effect {
+    inset: 0;
+    width: auto;
+    height: auto;
+    translate: none;
+  }
+}
+
+.q-navbar--horizontal:has(> .q-nav-item:nth-child(3):last-child) > .q-nav-item {
+  min-width: 20%;
+  max-width: calc(100% / 3);
+}
+
+.q-navbar--horizontal:has(> .q-nav-item:nth-child(4):last-child) > .q-nav-item {
+  min-width: 17.5%;
+  max-width: 25%;
+}
+
+.q-navbar--horizontal:has(> .q-nav-item:nth-child(5):last-child) > .q-nav-item {
+  min-width: 16%;
+  max-width: 20%;
+}
+
+.q-railbar > .q-nav-item {
+  flex: 0 0 auto;
+  width: 100%;
+  min-height: 3.5rem;
+  padding-block: 0.125rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .q-nav-item__indicator,
+  .q-nav-item__icon > .q-icon {
+    transition: none;
+  }
+}

--- a/src/lib/components/navbar/QNavItem.svelte
+++ b/src/lib/components/navbar/QNavItem.svelte
@@ -1,0 +1,152 @@
+<script lang="ts">
+  import QIconSnippet from "$internal/QIconSnippet.svelte";
+  import { ripple } from "$helpers";
+  import { getRouterInfo, isActivationKey, type QEvent } from "$utils";
+  import type { QNavItemProps } from "./props";
+
+  type QNavItemElement = HTMLAnchorElement | HTMLButtonElement;
+  type QNavItemEvent<T extends Event> = QEvent<T, QNavItemElement>;
+
+  // #region:    --- Props
+  let {
+    active,
+    activeClass,
+    activeStyle,
+    icon,
+    label,
+    badge,
+    badgeAriaLabel,
+    disabled = false,
+    noRipple = false,
+    rippleColor,
+    href,
+    to,
+    replace = false,
+    target,
+    tabindex,
+    style,
+    onclick,
+    onkeydown,
+    children,
+    ...props
+  }: QNavItemProps = $props();
+  // #endregion: --- Props
+
+  // #region:    --- Non-reactive variables
+  const uid = $props.id();
+  // #endregion: --- Non-reactive variables
+
+  // #region:    --- Derived values
+  const routerInfo = $derived(getRouterInfo({ href, to, replace }));
+  const tag = $derived(routerInfo.hasLink ? "a" : "button");
+  const isActive = $derived(active ?? !!routerInfo.isActive);
+  const itemStyle = $derived(
+    [isActive && activeStyle, style].filter(Boolean).join("; ") || undefined
+  );
+  const visualBadgeId = `${uid}-badge`;
+  const badgeLabelId = `${uid}-badge-label`;
+  const ariaDescribedby = $derived(
+    [props["aria-describedby"], badge && (badgeAriaLabel ? badgeLabelId : visualBadgeId)]
+      .filter(Boolean)
+      .join(" ") || undefined
+  );
+  // #endregion: --- Derived values
+
+  // #region:    --- Effects
+  $effect.pre(() => {
+    if (label === undefined && !children) {
+      console.warn("QNavItem should have a visible label supplied by `label` or `children`.");
+    }
+  });
+  // #endregion: --- Effects
+
+  // #region:    --- Functions
+  function handleClick(event: QNavItemEvent<MouseEvent>) {
+    if (disabled) {
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      return;
+    }
+
+    onclick?.(event);
+  }
+
+  function handleKeydown(event: QNavItemEvent<KeyboardEvent>) {
+    if (disabled) {
+      return;
+    }
+
+    onkeydown?.(event);
+
+    if (event.defaultPrevented || tag !== "a" || !isActivationKey(event)) {
+      return;
+    }
+
+    if (event.code !== "Enter") {
+      event.preventDefault();
+      event.currentTarget.click();
+    }
+  }
+  // #endregion: --- Functions
+
+  Q.classes("q-nav-item", {
+    bemClasses: {
+      active: isActive,
+      "no-ripple": noRipple,
+    },
+    classes: [routerInfo.linkClass, isActive && activeClass, props.class],
+  });
+</script>
+
+<!-- eslint-disable svelte/no-navigation-without-resolve -- Link attributes are normalized by getRouterInfo. -->
+<svelte:element
+  this={tag}
+  {...props}
+  class="q-nav-item"
+  style={itemStyle}
+  type={tag === "button" ? "button" : undefined}
+  href={disabled ? undefined : routerInfo.linkAttributes.href}
+  data-sveltekit-replacestate={routerInfo.linkAttributes["data-sveltekit-replacestate"]}
+  disabled={tag === "button" ? disabled : undefined}
+  aria-disabled={disabled || undefined}
+  aria-current={isActive ? (props["aria-current"] ?? "page") : props["aria-current"]}
+  aria-describedby={ariaDescribedby}
+  tabindex={disabled ? -1 : tabindex}
+  {target}
+  onclick={handleClick}
+  onkeydown={handleKeydown}
+  {@attach ripple({
+    center: true,
+    disabled: noRipple || disabled,
+    color: rippleColor,
+    effectTarget: ".q-nav-item__target",
+  })}
+  data-quaff
+>
+  <span class="q-nav-item__target">
+    <span class="q-nav-item__indicator" aria-hidden="true"></span>
+
+    <span class="q-nav-item__icon" aria-hidden="true">
+      <QIconSnippet {icon} size={24} filled={isActive} />
+
+      {#if badge}
+        <span id={visualBadgeId} class="q-nav-item__badge" aria-hidden="true">
+          {@render badge()}
+        </span>
+      {/if}
+    </span>
+
+    <span class="q-nav-item__label">
+      {#if label !== undefined}
+        {label}
+      {:else}
+        {@render children?.()}
+      {/if}
+    </span>
+  </span>
+
+  {#if badge && badgeAriaLabel}
+    <span id={badgeLabelId} hidden>{badgeAriaLabel}</span>
+  {/if}
+</svelte:element>
+<!-- eslint-enable svelte/no-navigation-without-resolve -->

--- a/src/lib/components/navbar/QNavbar.scss
+++ b/src/lib/components/navbar/QNavbar.scss
@@ -1,0 +1,25 @@
+@use "$css/mixins";
+
+.q-navbar {
+  z-index: 4;
+  position: fixed;
+  inset: auto 0 0;
+
+  box-sizing: border-box;
+  display: flex;
+  justify-content: center;
+
+  min-height: calc(var(--q-navbar-min-height, 4rem) + env(safe-area-inset-bottom, 0px));
+  padding: 0 env(safe-area-inset-right, 0px) env(safe-area-inset-bottom, 0px)
+    env(safe-area-inset-left, 0px);
+
+  overflow: visible;
+  border: 0;
+  border-radius: 0;
+  background-color: var(--surface-container);
+  color: var(--on-surface-variant);
+
+  &.q-navbar--bordered {
+    @include mixins.border($position: "top");
+  }
+}

--- a/src/lib/components/navbar/QNavbar.svelte
+++ b/src/lib/components/navbar/QNavbar.svelte
@@ -1,0 +1,69 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { useColor } from "$composables";
+  import { navbarCtx } from "../layout/QLayout.svelte";
+  import type { QNavbarProps } from "./props";
+
+  // #region:    --- Props
+  let {
+    activeColor = "secondary-container",
+    height = 64,
+    bordered = false,
+    horizontal = false,
+    children,
+    ...props
+  }: QNavbarProps = $props();
+  // #endregion: --- Props
+
+  // #region:    --- Reactive variables
+  let navbarEl = $state<HTMLElement>();
+
+  const layoutContext = navbarCtx.get();
+  const parsedActiveColor = $derived(
+    activeColor === "secondary-container" ? undefined : useColor(activeColor)
+  );
+  // #endregion: --- Reactive variables
+
+  // #region:    --- Lifecycle
+  onMount(() => {
+    if (!layoutContext || !navbarEl) {
+      return;
+    }
+
+    const updateLayout = () => {
+      layoutContext.height = navbarEl?.getBoundingClientRect().height ?? 0;
+      layoutContext.ready = true;
+    };
+    const resizeObserver = new ResizeObserver(updateLayout);
+
+    updateLayout();
+    resizeObserver.observe(navbarEl);
+
+    return () => {
+      resizeObserver.disconnect();
+      layoutContext.height = 0;
+      layoutContext.ready = false;
+    };
+  });
+  // #endregion: --- Lifecycle
+
+  Q.classes("q-navbar", {
+    bemClasses: {
+      bordered,
+      horizontal,
+    },
+    classes: [props.class],
+  });
+</script>
+
+<nav
+  bind:this={navbarEl}
+  {...props}
+  class="q-navbar"
+  style:--q-navbar-min-height="{height}px"
+  style:--q-nav-item-active-indicator-color={parsedActiveColor}
+  aria-label={props["aria-label"] ?? "Primary navigation"}
+  data-quaff
+>
+  {@render children?.()}
+</nav>

--- a/src/lib/components/navbar/docs.ts
+++ b/src/lib/components/navbar/docs.ts
@@ -1,0 +1,43 @@
+import type { QComponentDocs } from "$docs";
+import {
+  QNavbarDocsProps,
+  QNavbarDocsSnippets,
+  QNavbarDocsDomAttributesConstraint,
+  QNavbarDocsGenerics,
+  QNavbarDocsTypeDependencies,
+  QNavItemDocsProps,
+  QNavItemDocsSnippets,
+  QNavItemDocsDomAttributesConstraint,
+  QNavItemDocsGenerics,
+  QNavItemDocsTypeDependencies,
+} from "./docs.props";
+
+export const QNavbarDocs: QComponentDocs = {
+  name: "QNavbar",
+  description:
+    "Navigation bars provide access to three to five primary destinations from the bottom of a layout.",
+  docs: {
+    generics: QNavbarDocsGenerics,
+    domAttributesConstraint: QNavbarDocsDomAttributesConstraint,
+    props: QNavbarDocsProps,
+    snippets: QNavbarDocsSnippets,
+    methods: [],
+    events: [],
+    typeDependencies: QNavbarDocsTypeDependencies,
+  },
+};
+
+export const QNavItemDocs: QComponentDocs = {
+  name: "QNavItem",
+  description:
+    "Navigation items represent destinations inside navigation bars and railbars, with optional badges.",
+  docs: {
+    generics: QNavItemDocsGenerics,
+    domAttributesConstraint: QNavItemDocsDomAttributesConstraint,
+    props: QNavItemDocsProps,
+    snippets: QNavItemDocsSnippets,
+    methods: [],
+    events: [],
+    typeDependencies: QNavItemDocsTypeDependencies,
+  },
+};

--- a/src/lib/components/navbar/props.ts
+++ b/src/lib/components/navbar/props.ts
@@ -1,0 +1,73 @@
+import type { Borderable, Clickable, Linkable, WithActiveAttrs } from "$utils";
+import type { MaterialSymbol } from "material-symbols";
+import type { Snippet } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+
+export interface QNavbarProps extends Borderable, Omit<HTMLAttributes<HTMLElement>, "children"> {
+  /**
+   * Color of active destination indicators. Use a theme container color such as
+   * `primary-container`. See <link to colors docs> for supported color values.
+   *
+   * @default "secondary-container"
+   */
+  activeColor?: string;
+
+  /**
+   * Minimum height of the navigation bar in pixels, excluding the bottom safe-area inset.
+   *
+   * @default 64
+   */
+  height?: number;
+
+  /**
+   * Places each destination's icon and label next to each other. Material Design recommends this
+   * arrangement for medium-width layouts from 600px through 839px.
+   *
+   * @default false
+   */
+  horizontal?: boolean;
+
+  /**
+   * Three to five stable, equal-priority destinations rendered as `QNavItem` components.
+   */
+  children?: Snippet;
+}
+
+export interface QNavItemProps
+  extends Clickable, Linkable, WithActiveAttrs, Omit<HTMLAttributes<HTMLElement>, "children"> {
+  /**
+   * Marks the item as the current destination and overrides automatic route matching when set.
+   * Router links are activated automatically when this prop is omitted.
+   */
+  active?: boolean;
+
+  /**
+   * Material Symbol name or custom snippet displayed at 24px. Material Symbols fill automatically
+   * when active; custom snippets should provide their own active-state treatment when needed.
+   */
+  icon: MaterialSymbol | Snippet;
+
+  /**
+   * Visible one- or two-word destination label. Every item should provide this prop or the default
+   * children snippet.
+   */
+  label?: string;
+
+  /**
+   * Visible destination label used when the `label` prop is omitted.
+   */
+  children?: Snippet;
+
+  /**
+   * Badge content displayed on the icon. An empty snippet renders a dot badge; text renders the
+   * larger badge variant. Use plain text limited to four characters including `+`, such as `999+`.
+   */
+  badge?: Snippet;
+
+  /**
+   * Accessible badge description announced after the destination label. Provide this whenever the
+   * badge conveys information, and always for an otherwise silent dot badge (for example,
+   * `"New notification"`).
+   */
+  badgeAriaLabel?: string;
+}

--- a/src/lib/components/railbar/QRailbar.scss
+++ b/src/lib/components/railbar/QRailbar.scss
@@ -1,5 +1,4 @@
 @use "$css/mixins";
-@use "$css/variables";
 
 .q-railbar {
   z-index: 5;
@@ -14,7 +13,7 @@
   text-align: center;
 
   @include mixins.padding("y-sm");
-  @include mixins.gap("md");
+  @include mixins.gap("sm");
 
   background-color: var(--surface);
   color: var(--on-surface);
@@ -28,92 +27,6 @@
 
   &::-webkit-scrollbar {
     display: none;
-  }
-
-  & > .q-list {
-    @include mixins.gap("sm");
-
-    & > .q-item {
-      display: grid;
-      grid-template: 2rem 1rem / 100%;
-      align-content: center;
-      justify-items: center;
-      gap: 0.25rem;
-
-      height: 3.5rem;
-      padding: 0.125rem 0;
-      border-radius: 0;
-      color: var(--on-surface-variant);
-
-      &:is(:hover, :focus):not([aria-disabled])::after {
-        inset: 0.125rem auto auto 50%;
-        width: 3.5rem;
-        height: 2rem;
-        border-radius: 2rem;
-        background-color: var(--on-surface-variant);
-        translate: -50%;
-      }
-
-      &:focus:not([aria-disabled])::after {
-        opacity: 0.12;
-      }
-
-      & > .q-icon {
-        isolation: isolate;
-        transition: font-variation-settings variables.$speed2 cubic-bezier(0.2, 0, 0, 1);
-
-        &::before {
-          content: "";
-          z-index: -1;
-          position: absolute;
-          inset: 50% auto auto 50%;
-          width: 3.5rem;
-          height: 2rem;
-          border-radius: 2rem;
-          background-color: var(--secondary-container);
-          opacity: 0;
-          transform: scaleX(0.32);
-          translate: -50% -50%;
-          transition:
-            transform variables.$speed2 linear,
-            opacity variables.$speed2 linear;
-        }
-      }
-
-      & > .q-item__section {
-        color: inherit;
-      }
-
-      & > .q-item__section .q-item__section--headline {
-        @include mixins.typography("label-medium");
-        color: inherit;
-      }
-
-      & > .q-ripple__effect {
-        inset: 0.125rem auto auto 50%;
-        width: 3.5rem;
-        height: 2rem;
-        border-radius: 2rem;
-        translate: -50%;
-      }
-
-      &.q-item--active {
-        color: var(--on-secondary-container);
-
-        & > .q-icon {
-          font-variation-settings: "FILL" 1;
-
-          &::before {
-            opacity: 1;
-            transform: scaleX(1);
-          }
-        }
-
-        &:is(:hover, :focus):not([aria-disabled])::after {
-          background-color: var(--on-secondary-container);
-        }
-      }
-    }
   }
 
   @each $side in ("left", "right") {

--- a/src/lib/components/railbar/QRailbar.svelte
+++ b/src/lib/components/railbar/QRailbar.svelte
@@ -1,10 +1,18 @@
 <script lang="ts">
   import { onMount } from "svelte";
+  import { useColor } from "$composables";
   import { leftRailbarCtx, rightRailbarCtx } from "../layout/QLayout.svelte";
   import type { QRailbarProps } from "./props";
 
   // #region:    --- Props
-  let { width = 80, side = "left", bordered = false, children, ...props }: QRailbarProps = $props();
+  let {
+    activeColor = "secondary-container",
+    width = 80,
+    side = "left",
+    bordered = false,
+    children,
+    ...props
+  }: QRailbarProps = $props();
   // #endregion: --- Props
 
   // #region:    --- Non-reactive variables
@@ -25,6 +33,9 @@
   });
 
   const railbarWidthStyle = $derived(`--${side}-railbar-width: ${width}px`);
+  const parsedActiveColor = $derived(
+    activeColor === "secondary-container" ? undefined : useColor(activeColor)
+  );
 
   const style = $derived(`${railbarWidthStyle};${props.style ?? ""}`);
   // #endregion: --- Derived values
@@ -62,6 +73,13 @@
   });
 </script>
 
-<nav bind:this={railbarEl} {...props} class="q-railbar" {style} data-quaff>
+<nav
+  bind:this={railbarEl}
+  {...props}
+  class="q-railbar"
+  {style}
+  style:--q-nav-item-active-indicator-color={parsedActiveColor}
+  data-quaff
+>
   {@render children?.()}
 </nav>

--- a/src/lib/components/railbar/props.ts
+++ b/src/lib/components/railbar/props.ts
@@ -3,6 +3,14 @@ import type { HTMLAttributes } from "svelte/elements";
 
 export interface QRailbarProps extends Borderable, HTMLAttributes<HTMLElement> {
   /**
+   * Color of active destination indicators. Use a theme container color such as
+   * `primary-container`. See <link to colors docs> for supported color values.
+   *
+   * @default "secondary-container"
+   */
+  activeColor?: string;
+
+  /**
    * Width of the railbar in pixels.
    */
   width?: number;

--- a/src/lib/css/_components.scss
+++ b/src/lib/css/_components.scss
@@ -21,6 +21,8 @@
 @forward "$components/list/QItemSection.scss";
 @forward "$components/list/QList.scss";
 @forward "$components/menu/QMenu.scss";
+@forward "$components/navbar/QNavbar.scss";
+@forward "$components/navbar/QNavItem.scss";
 @forward "$components/progress/QCircularProgress.scss";
 @forward "$components/progress/QLinearProgress.scss";
 @forward "$components/radio/QRadio.scss";

--- a/src/lib/css/components/navbar.scss
+++ b/src/lib/css/components/navbar.scss
@@ -1,0 +1,10 @@
+@use "sass:meta";
+
+@layer theme, ripple, components, classes, disabled;
+
+@layer Quaff {
+  @layer components {
+    @include meta.load-css("../../components/navbar/QNavbar.scss");
+    @include meta.load-css("../../components/navbar/QNavItem.scss");
+  }
+}

--- a/src/lib/helpers/ripple.ts
+++ b/src/lib/helpers/ripple.ts
@@ -21,6 +21,10 @@ interface RippleOptions {
    * Whether the ripple should be disabled.
    */
   disabled?: boolean;
+  /**
+   * A selector for a descendant that should contain the ripple effect.
+   */
+  effectTarget?: string;
 }
 
 const TRIGGER_EVENTS = ["pointerdown", "touchstart", "keydown"] as const;
@@ -59,7 +63,12 @@ export function ripple(options: RippleOptions = {}): Attachment<HTMLElement> {
     }
 
     rippleContainer = document.createElement("div");
-    el.appendChild(rippleContainer);
+
+    const effectTarget = options.effectTarget
+      ? (el.querySelector<HTMLElement>(options.effectTarget) ?? el)
+      : el;
+
+    effectTarget.appendChild(rippleContainer);
 
     if (duration) {
       rippleContainer.style.setProperty(DURATION_PROPERTY, `${duration}ms`);
@@ -98,20 +107,26 @@ export function ripple(options: RippleOptions = {}): Attachment<HTMLElement> {
     const rippleContainer = getRippleContainer(el);
     addClasses(rippleContainer, center);
 
-    const rect = el.getBoundingClientRect();
+    const rect = options.effectTarget
+      ? rippleContainer.getBoundingClientRect()
+      : el.getBoundingClientRect();
 
     const { clientX, clientY } =
       window.TouchEvent && event instanceof TouchEvent ? event.touches[0] : (event as PointerEvent);
 
-    const x = clientX - rect.left > el.offsetWidth / 2 ? 0 : el.offsetWidth;
-    const y = clientY - rect.top > el.offsetHeight / 2 ? 0 : el.offsetHeight;
-    const radius = Math.hypot(x - (clientX - rect.left), y - (clientY - rect.top));
+    const localX =
+      options.effectTarget && (center || options.center) ? rect.width / 2 : clientX - rect.left;
+    const localY =
+      options.effectTarget && (center || options.center) ? rect.height / 2 : clientY - rect.top;
+    const x = localX > rect.width / 2 ? 0 : rect.width;
+    const y = localY > rect.height / 2 ? 0 : rect.height;
+    const radius = Math.hypot(x - localX, y - localY);
 
     const ripple = document.createElement("div");
     ripple.classList.add(RIPPLE_CLASS);
 
-    ripple.style.left = `${clientX - rect.left - radius}px`;
-    ripple.style.top = `${clientY - rect.top - radius}px`;
+    ripple.style.left = `${localX - radius}px`;
+    ripple.style.top = `${localY - radius}px`;
     ripple.style.width = ripple.style.height = `${radius * 2}px`;
 
     rippleContainer.appendChild(ripple);

--- a/src/lib/internal/componentRegistry.ts
+++ b/src/lib/internal/componentRegistry.ts
@@ -30,6 +30,8 @@ export const Components = {
   QItemSection: "QItemSection",
   QLinearProgress: "QLinearProgress",
   QMenu: "QMenu",
+  QNavbar: "QNavbar",
+  QNavItem: "QNavItem",
   QRadio: "QRadio",
   QRailbar: "QRailbar",
   QSeparator: "QSeparator",
@@ -60,6 +62,7 @@ export const ComponentPaths = {
   Layout: "layout",
   List: "list",
   Menu: "menu",
+  Navbar: "navbar",
   Progress: "progress",
   Radio: "radio",
   Railbar: "railbar",
@@ -93,6 +96,7 @@ export const ComponentCss = {
   Layout: "components/layout",
   List: "components/list",
   Menu: "components/menu",
+  Navbar: "components/navbar",
   Progress: "components/progress",
   Radio: "components/radio",
   Railbar: "components/railbar",
@@ -121,6 +125,7 @@ const expansionItemCss = [
   ComponentCss.Progress,
 ];
 const fieldCss = [ComponentCss.Field];
+const navbarCss = [ComponentCss.Navbar, ComponentCss.Icon];
 const selectCss = [
   ComponentCss.Field,
   ComponentCss.Select,
@@ -166,6 +171,8 @@ export const ComponentCssDependencies = {
   [Components.QItemSection]: [ComponentCss.List],
   [Components.QLinearProgress]: [ComponentCss.Progress],
   [Components.QMenu]: [ComponentCss.Menu],
+  [Components.QNavbar]: [ComponentCss.Navbar],
+  [Components.QNavItem]: navbarCss,
   [Components.QRadio]: [ComponentCss.Radio],
   [Components.QRailbar]: [ComponentCss.Railbar],
   [Components.QSeparator]: [ComponentCss.Separator],
@@ -196,6 +203,7 @@ export const ComponentPathCssDependencies = {
   [ComponentPaths.Layout]: [ComponentCss.Layout],
   [ComponentPaths.List]: [ComponentCss.List],
   [ComponentPaths.Menu]: [ComponentCss.Menu],
+  [ComponentPaths.Navbar]: navbarCss,
   [ComponentPaths.Progress]: [ComponentCss.Progress],
   [ComponentPaths.Radio]: [ComponentCss.Radio],
   [ComponentPaths.Railbar]: [ComponentCss.Railbar],

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -14,6 +14,7 @@
     QItemSection,
     QLayout,
     QList,
+    QNavItem,
     QRailbar,
     QTheme,
     Quaff,
@@ -131,6 +132,10 @@
     {
       name: "Menu",
       to: "/components/menu",
+    },
+    {
+      name: "Navbar",
+      to: "/components/navbar",
     },
     {
       name: "Progress",
@@ -389,7 +394,9 @@
 
 {#snippet railbar()}
   <QRailbar class="surface" bordered width={120}>
-    {@render mainRoutesList()}
+    {#each pages as { name, icon, to } (`${name}-${icon}-${to}`)}
+      <QNavItem {icon} label={name} {to} noRipple />
+    {/each}
   </QRailbar>
 {/snippet}
 

--- a/src/routes/components/+page.svelte
+++ b/src/routes/components/+page.svelte
@@ -26,6 +26,8 @@
     QLayout,
     QLinearProgress,
     QList,
+    QNavbar,
+    QNavItem,
     QRadio,
     QRailbar,
     QSelect,
@@ -166,6 +168,12 @@
       snippet: menu,
     },
     {
+      name: "QNavbar",
+      description: "Navigate between primary destinations from a fixed bottom bar.",
+      href: "/components/navbar",
+      snippet: navbar,
+    },
+    {
       name: "QProgress",
       description: "Indicate task completion or loading status with linear or cicular indicators.",
       href: "/components/progress",
@@ -176,6 +184,12 @@
       description: "Enable exclusive choices from a set using radio buttons.",
       href: "/components/radio",
       snippet: radio,
+    },
+    {
+      name: "QRailbar",
+      description: "Navigate between primary destinations from a fixed side rail.",
+      href: "/components/railbar",
+      snippet: railbar,
     },
     {
       name: "QSelect",
@@ -621,6 +635,26 @@
   </div>
 {/snippet}
 
+{#snippet navbar()}
+  <QLayout class="background" style="height: 100%; width: 100%;">
+    {#snippet content()}
+      <div class="flex flex-center" style="height: 100%;">
+        <span class="headline-small">Home</span>
+      </div>
+    {/snippet}
+
+    {#snippet navbar()}
+      <QNavbar bordered>
+        <QNavItem icon="home" label="Home" active />
+        <QNavItem icon="search" label="Explore" />
+        <QNavItem icon="notifications" label="Updates" badgeAriaLabel="3 unread updates">
+          {#snippet badge()}3{/snippet}
+        </QNavItem>
+      </QNavbar>
+    {/snippet}
+  </QLayout>
+{/snippet}
+
 {#snippet radio()}
   <QList class="surface q-pa-lg" style="width: 100%; min-width: min-content;" dense>
     <QItem class="headline-small">Language</QItem>
@@ -634,6 +668,24 @@
       <QRadio value="chinese" label="Chinese (Mandarin)" />
     </QItem>
   </QList>
+{/snippet}
+
+{#snippet railbar()}
+  <QLayout class="background" style="height: 100%; width: 100%;">
+    {#snippet content()}
+      <div class="flex flex-center" style="height: 100%;">
+        <span class="headline-small">Home</span>
+      </div>
+    {/snippet}
+
+    {#snippet railbarLeft()}
+      <QRailbar bordered width={72} activeColor="primary-container" class="q-py-xs">
+        <QNavItem icon="home" label="Home" active />
+        <QNavItem icon="person" label="Profile" />
+        <QNavItem icon="settings" label="Settings" />
+      </QRailbar>
+    {/snippet}
+  </QLayout>
 {/snippet}
 
 {#snippet select()}

--- a/src/routes/components/layout/+page.svelte
+++ b/src/routes/components/layout/+page.svelte
@@ -12,6 +12,7 @@
     QItemSection,
     QLayout,
     QList,
+    QNavItem,
     QRadio,
     QRailbar,
     QSwitch,
@@ -103,16 +104,8 @@
       {/snippet}
       {#snippet railbarRight()}
         <QRailbar side="right" bordered>
-          <QList>
-            <QItem to="#">
-              <QIcon name="home" />
-              <QItemSection>Home</QItemSection>
-            </QItem>
-            <QItem to="#">
-              <QIcon name="help" />
-              <QItemSection>About</QItemSection>
-            </QItem>
-          </QList>
+          <QNavItem icon="home" label="Home" to="#" />
+          <QNavItem icon="help" label="About" to="#" />
         </QRailbar>
       {/snippet}
       {#snippet footer()}
@@ -254,47 +247,19 @@
 
 {#snippet railbarLeft()}
   <QRailbar bordered>
-    <QList>
-      <QItem to="#" noRipple>
-        <QIcon name="home" />
-        <QItemSection>Home</QItemSection>
-      </QItem>
-      <QItem to="#" noRipple>
-        <QIcon name="help" />
-        <QItemSection>About</QItemSection>
-      </QItem>
-      <QItem to="#" noRipple>
-        <QIcon name="shopping_cart" />
-        <QItemSection>Store</QItemSection>
-      </QItem>
-      <QItem to="#" noRipple>
-        <QIcon name="mail" />
-        <QItemSection>Contact</QItemSection>
-      </QItem>
-    </QList>
+    <QNavItem icon="home" label="Home" to="#" noRipple />
+    <QNavItem icon="help" label="About" to="#" noRipple />
+    <QNavItem icon="shopping_cart" label="Store" to="#" noRipple />
+    <QNavItem icon="mail" label="Contact" to="#" noRipple />
   </QRailbar>
 {/snippet}
 
 {#snippet railbarRight()}
   <QRailbar side="right" bordered>
-    <QList>
-      <QItem to="#" noRipple>
-        <QIcon name="home" />
-        <QItemSection>Home</QItemSection>
-      </QItem>
-      <QItem to="#" noRipple>
-        <QIcon name="help" />
-        <QItemSection>About</QItemSection>
-      </QItem>
-      <QItem to="#" noRipple>
-        <QIcon name="shopping_cart" />
-        <QItemSection>Store</QItemSection>
-      </QItem>
-      <QItem to="#" noRipple>
-        <QIcon name="mail" />
-        <QItemSection>Contact</QItemSection>
-      </QItem>
-    </QList>
+    <QNavItem icon="home" label="Home" to="#" noRipple />
+    <QNavItem icon="help" label="About" to="#" noRipple />
+    <QNavItem icon="shopping_cart" label="Store" to="#" noRipple />
+    <QNavItem icon="mail" label="Contact" to="#" noRipple />
   </QRailbar>
 {/snippet}
 

--- a/src/routes/components/layout/docs.snippets.ts
+++ b/src/routes/components/layout/docs.snippets.ts
@@ -34,27 +34,39 @@ function navbarBuilder(kind: "railbar" | "drawer", side: "left" | "right") {
     attributes.push("persistent", `bind:value={${side}DrawerShown}`)
   }
 
+  const items =
+    kind === "railbar"
+      ? [
+          `      <QNavItem icon="home" label="Home" to="#" />`,
+          `      <QNavItem icon="help" label="About" to="#" />`,
+          `      <QNavItem icon="shopping_cart" label="Store" to="#" />`,
+          `      <QNavItem icon="mail" label="Contact" to="#" />`,
+        ]
+      : [
+          `      <QList>`,
+          `        <QItem to="#">`,
+          `          <QIcon name="home" />`,
+          `          <QItemSection>Home</QItemSection>`,
+          `        </QItem>`,
+          `        <QItem to="#">`,
+          `          <QIcon name="help" />`,
+          `          <QItemSection>About</QItemSection>`,
+          `        </QItem>`,
+          `        <QItem to="#">`,
+          `          <QIcon name="shopping_cart" />`,
+          `          <QItemSection>Store</QItemSection>`,
+          `        </QItem>`,
+          `        <QItem to="#">`,
+          `          <QIcon name="mail" />`,
+          `          <QItemSection>Contact</QItemSection>`,
+          `        </QItem>`,
+          `      </QList>`,
+        ]
+
   return [
     `  {#snippet ${kind}${capitalize(side)}()}`,
     `    <Q${capitalize(kind)} ${attributes.join(" ")}>`,
-    `      <QList>`,
-    `        <QItem to="#">`,
-    `          <QIcon name="home" />`,
-    `          <QItemSection>Home</QItemSection>`,
-    `        </QItem>`,
-    `        <QItem to="#">`,
-    `          <QIcon name="help" />`,
-    `          <QItemSection>About</QItemSection>`,
-    `        </QItem>`,
-    `        <QItem to="#">`,
-    `          <QIcon name="shopping_cart" />`,
-    `          <QItemSection>Store</QItemSection>`,
-    `        </QItem>`,
-    `        <QItem to="#">`,
-    `          <QIcon name="mail" />`,
-    `          <QItemSection>Contact</QItemSection>`,
-    `        </QItem>`,
-    `      </QList>`,
+    ...items,
     `    </Q${capitalize(kind)}>`,
     `  {/snippet}\n`,
   ].join("\n")

--- a/src/routes/components/navbar/+page.svelte
+++ b/src/routes/components/navbar/+page.svelte
@@ -1,0 +1,243 @@
+<script lang="ts">
+  import { QNavbarDocs, QNavItemDocs } from "$components/navbar/docs";
+  import { QDocs, QDocsSection } from "$docs";
+  import { docsCtx } from "$docs/QDocs.svelte";
+  import { pageTitle } from "$helpers/pageTitle";
+  import { QLayout, QNavbar, QNavItem } from "$lib";
+  import snippets from "./docs.snippets";
+
+  docsCtx.set({ snippets, componentDocs: [QNavbarDocs, QNavItemDocs] });
+
+  let selectedDestination = $state("home");
+</script>
+
+<svelte:head>
+  <title>{pageTitle("QNavbar")}</title>
+</svelte:head>
+
+<QDocs>
+  {#snippet display()}
+    <QLayout style="height: 280px;">
+      {#snippet content()}
+        <div class="flex flex-center column" style="height: 100%;">
+          <h5>{selectedDestination}</h5>
+          <span class="text-on-surface-variant">Selected destination</span>
+        </div>
+      {/snippet}
+
+      {#snippet navbar()}
+        <QNavbar aria-label="Primary navigation">
+          <QNavItem
+            icon="home"
+            label="Home"
+            active={selectedDestination === "home"}
+            onclick={() => (selectedDestination = "home")}
+          />
+          <QNavItem
+            icon="search"
+            label="Explore"
+            active={selectedDestination === "explore"}
+            onclick={() => (selectedDestination = "explore")}
+          />
+          <QNavItem
+            icon="person"
+            label="Profile"
+            active={selectedDestination === "profile"}
+            onclick={() => (selectedDestination = "profile")}
+          />
+        </QNavbar>
+      {/snippet}
+    </QLayout>
+  {/snippet}
+
+  {#snippet usage()}
+    <div>
+      <QDocsSection title="QLayout Integration">
+        {#snippet sectionDescription()}
+          Place QNavbar in QLayout's <code>navbar</code> snippet. QLayout reserves space at the bottom
+          of its content for the bar, while QNavItem represents each primary destination. Use three to
+          five stable, equal-priority top-level destinations, keep exactly one active, and always show
+          concise one- or two-word labels.
+        {/snippet}
+
+        <div style="height: 300px; border: 1px solid var(--outline-variant);">
+          <QLayout>
+            {#snippet content()}
+              <div class="flex flex-center column" style="height: 100%;">
+                <h5>{selectedDestination}</h5>
+                <p class="text-on-surface-variant">Choose a destination below.</p>
+              </div>
+            {/snippet}
+
+            {#snippet navbar()}
+              <QNavbar aria-label="Example primary navigation">
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  active={selectedDestination === "home"}
+                  onclick={() => (selectedDestination = "home")}
+                />
+                <QNavItem
+                  icon="search"
+                  label="Explore"
+                  active={selectedDestination === "explore"}
+                  onclick={() => (selectedDestination = "explore")}
+                />
+                <QNavItem
+                  icon="favorite"
+                  label="Favorites"
+                  active={selectedDestination === "favorites"}
+                  onclick={() => (selectedDestination = "favorites")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  active={selectedDestination === "profile"}
+                  onclick={() => (selectedDestination = "profile")}
+                />
+              </QNavbar>
+            {/snippet}
+          </QLayout>
+        </div>
+      </QDocsSection>
+
+      <QDocsSection title="Badges">
+        {#snippet sectionDescription()}
+          Provide the <code>badge</code> snippet to add a badge to a navigation item. An empty
+          snippet renders the 6px dot variant; plain text renders the larger variant and should be
+          limited to four characters including <code>+</code>, such as <code>999+</code>. Use
+          <code>badgeAriaLabel</code> whenever the badge conveys information, and always for a dot. For
+          a dot, use a description such as “New notification”. Remove an unread marker once its destination
+          is selected.
+        {/snippet}
+
+        <div style="height: 260px; border: 1px solid var(--outline-variant);">
+          <QLayout>
+            {#snippet content()}
+              <div class="flex flex-center" style="height: 100%;">
+                <span class="headline-small">Inbox</span>
+              </div>
+            {/snippet}
+
+            {#snippet navbar()}
+              <QNavbar aria-label="Inbox navigation">
+                <QNavItem icon="home" label="Home" active />
+                <QNavItem icon="notifications" label="Updates" badgeAriaLabel="New notification">
+                  {#snippet badge()}{/snippet}
+                </QNavItem>
+                <QNavItem icon="chat" label="Messages" badgeAriaLabel="3 unread messages">
+                  {#snippet badge()}3{/snippet}
+                </QNavItem>
+                <QNavItem icon="inbox" label="Inbox" badgeAriaLabel="More than 999 unread emails">
+                  {#snippet badge()}999+{/snippet}
+                </QNavItem>
+              </QNavbar>
+            {/snippet}
+          </QLayout>
+        </div>
+      </QDocsSection>
+
+      <QDocsSection title="Horizontal Items">
+        {#snippet sectionDescription()}
+          Add <code>horizontal</code> for medium layouts from 600px through 839px. Use vertical items
+          below 600px and switch to a navigation rail at 840px and above.
+        {/snippet}
+
+        <div style="height: 260px; border: 1px solid var(--outline-variant);">
+          <QLayout>
+            {#snippet content()}
+              <div class="flex flex-center" style="height: 100%;">
+                <span class="headline-small">Wide navigation</span>
+              </div>
+            {/snippet}
+
+            {#snippet navbar()}
+              <QNavbar horizontal aria-label="Wide primary navigation">
+                <QNavItem icon="home" label="Home" active />
+                <QNavItem icon="calendar_month" label="Calendar" badgeAriaLabel="New notification">
+                  {#snippet badge()}{/snippet}
+                </QNavItem>
+                <QNavItem icon="person" label="Profile" />
+              </QNavbar>
+            {/snippet}
+          </QLayout>
+        </div>
+      </QDocsSection>
+
+      <QDocsSection title="Links and Active State">
+        {#snippet sectionDescription()}
+          Use <code>href</code> for destinations; <code>to</code> is supported as an alias. The
+          <code>active</code>,
+          <code>activeClass</code>, and <code>activeStyle</code> props can mark the current
+          destination; router links can also become active from the current route, including nested
+          routes. Set
+          <code>activeColor</code> on QNavbar to customize the active indicator color.
+        {/snippet}
+
+        <div style="height: 260px; border: 1px solid var(--outline-variant);">
+          <QLayout>
+            {#snippet content()}
+              <div class="flex flex-center" style="height: 100%;">
+                <span class="headline-small">Linked destinations</span>
+              </div>
+            {/snippet}
+
+            {#snippet navbar()}
+              <QNavbar activeColor="primary-container" aria-label="Documentation navigation">
+                <QNavItem
+                  icon="widgets"
+                  label="Components"
+                  to="/components"
+                  active
+                  activeClass="text-secondary"
+                />
+                <QNavItem icon="view_quilt" label="Layout" to="/components/layout" />
+                <QNavItem
+                  icon="description"
+                  label="Material specs"
+                  href="https://m3.material.io/components/navigation-bar/specs"
+                  target="_blank"
+                  aria-label="Material navigation bar specifications (opens in a new tab)"
+                />
+                <QNavItem icon="block" label="Unavailable" disabled />
+              </QNavbar>
+            {/snippet}
+          </QLayout>
+        </div>
+      </QDocsSection>
+
+      <QDocsSection title="Custom Icons and Labels">
+        {#snippet sectionDescription()}
+          The required <code>icon</code> prop accepts a Material Symbol name or a snippet. Supply a
+          <code>label</code>, or use the default children snippet as its fallback. Keep visible
+          labels concise, and add an <code>aria-label</code> when a destination needs a fuller
+          accessible name. Custom icon content inherits the 24px icon size; when it has distinct
+          filled and outlined forms, choose the active form from the same state used by
+          <code>active</code>.
+        {/snippet}
+
+        <div style="height: 260px; border: 1px solid var(--outline-variant);">
+          <QLayout>
+            {#snippet content()}
+              <div class="flex flex-center" style="height: 100%;">
+                <span class="headline-small">Accessible labels</span>
+              </div>
+            {/snippet}
+
+            {#snippet navbar()}
+              <QNavbar aria-label="Custom primary navigation">
+                <QNavItem icon="home" active>Home</QNavItem>
+                <QNavItem aria-label="Saved favorites" label="Saved">
+                  {#snippet icon()}
+                    <span aria-hidden="true">★</span>
+                  {/snippet}
+                </QNavItem>
+                <QNavItem icon="settings" label="Settings" />
+              </QNavbar>
+            {/snippet}
+          </QLayout>
+        </div>
+      </QDocsSection>
+    </div>
+  {/snippet}
+</QDocs>

--- a/src/routes/components/railbar/+page.svelte
+++ b/src/routes/components/railbar/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import { docsCtx } from "$docs/QDocs.svelte";
+  import { QNavItemDocs } from "$components/navbar/docs";
   import { QRailbarDocs } from "$components/railbar/docs";
   import { pageTitle } from "$helpers/pageTitle";
   import {
@@ -13,12 +14,13 @@
     QItemSection,
     QLayout,
     QList,
+    QNavItem,
     QRailbar,
   } from "$lib";
   import { QDocs, QDocsSection } from "$docs";
   import snippets from "./docs.snippets";
 
-  docsCtx.set({ snippets, componentDocs: QRailbarDocs });
+  docsCtx.set({ snippets, componentDocs: [QRailbarDocs, QNavItemDocs] });
 
   let selectedRoute = $state("home");
   let leftDrawerOpen = $state(false);
@@ -34,35 +36,27 @@
     <QLayout view="hHh LpR fFf" style="height: 300px;">
       {#snippet railbarLeft()}
         <QRailbar bordered>
-          <QList>
-            <QItem
-              to="#"
-              active={selectedRoute === "home"}
-              clickable
-              onclick={() => (selectedRoute = "home")}
-            >
-              <QIcon name="home" />
-              <QItemSection>Home</QItemSection>
-            </QItem>
-            <QItem
-              to="#"
-              active={selectedRoute === "person"}
-              clickable
-              onclick={() => (selectedRoute = "person")}
-            >
-              <QIcon name="person" />
-              <QItemSection>Profile</QItemSection>
-            </QItem>
-            <QItem
-              to="#"
-              active={selectedRoute === "settings"}
-              clickable
-              onclick={() => (selectedRoute = "settings")}
-            >
-              <QIcon name="settings" />
-              <QItemSection>Settings</QItemSection>
-            </QItem>
-          </QList>
+          <QNavItem
+            icon="home"
+            label="Home"
+            to="#"
+            active={selectedRoute === "home"}
+            onclick={() => (selectedRoute = "home")}
+          />
+          <QNavItem
+            icon="person"
+            label="Profile"
+            to="#"
+            active={selectedRoute === "person"}
+            onclick={() => (selectedRoute = "person")}
+          />
+          <QNavItem
+            icon="settings"
+            label="Settings"
+            to="#"
+            active={selectedRoute === "settings"}
+            onclick={() => (selectedRoute = "settings")}
+          />
         </QRailbar>
       {/snippet}
     </QLayout>
@@ -73,48 +67,73 @@
       <QDocsSection title="Basic Railbar">
         {#snippet sectionDescription()}
           QRailbar provides access to primary destinations from a fixed position at the side of a
-          layout. It is intended for three to seven destinations on medium and large screens.
+          layout. It is intended for three to seven destinations on medium and large screens. Place
+          QNavItem components directly inside it so navigation styling stays scoped to navigation
+          items rather than QList and QItem.
         {/snippet}
 
         <div style="height: 300px; border: 1px solid var(--outline-variant);">
           <QLayout view="hHh LpR fFf">
             {#snippet railbarLeft()}
               <QRailbar>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
             <div class="flex flex-center column" style="height: 100%">
               <h5>Selected route: {selectedRoute}</h5>
               <p>Click the icons in the railbar to change the route.</p>
+            </div>
+          </QLayout>
+        </div>
+      </QDocsSection>
+
+      <QDocsSection title="Badges">
+        {#snippet sectionDescription()}
+          QNavItem badges work the same way in railbars and navigation bars. Use an empty
+          <code>badge</code> snippet for a 6px dot, or plain text of up to four characters including
+          <code>+</code> for a count. Describe meaningful badge information with
+          <code>badgeAriaLabel</code>; for a dot, use a description such as “New notification”.
+          Remove unread markers once the destination is selected.
+        {/snippet}
+
+        <div style="height: 300px; border: 1px solid var(--outline-variant);">
+          <QLayout view="hHh LpR fFf">
+            {#snippet railbarLeft()}
+              <QRailbar aria-label="Inbox navigation">
+                <QNavItem icon="home" label="Home" active />
+                <QNavItem icon="notifications" label="Updates" badgeAriaLabel="New notification">
+                  {#snippet badge()}{/snippet}
+                </QNavItem>
+                <QNavItem icon="inbox" label="Inbox" badgeAriaLabel="More than 999 unread emails">
+                  {#snippet badge()}999+{/snippet}
+                </QNavItem>
+              </QRailbar>
+            {/snippet}
+
+            <div class="flex flex-center column" style="height: 100%">
+              <h5>Navigation badges</h5>
+              <p>Badges are anchored to each destination icon.</p>
             </div>
           </QLayout>
         </div>
@@ -130,35 +149,27 @@
           <QLayout view="hHh LpR fFf">
             {#snippet railbarLeft()}
               <QRailbar bordered>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
@@ -172,43 +183,35 @@
 
       <QDocsSection title="Right Side Railbar">
         {#snippet sectionDescription()}
-          Position the railbar on the right side of the layout using the <code>side</code>"right"
-          prop.
+          Position the railbar on the right side of the layout using
+          <code>side="right"</code>.
         {/snippet}
 
         <div style="height: 300px; border: 1px solid var(--outline-variant);">
           <QLayout view="hHh LpR fFf">
             {#snippet railbarRight()}
               <QRailbar side="right" bordered>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
@@ -229,35 +232,27 @@
           <QLayout view="hHh LpR fFf">
             {#snippet railbarLeft()}
               <QRailbar width={120} bordered>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
@@ -293,44 +288,34 @@
             <!-- Left Railbar -->
             {#snippet railbarLeft()}
               <QRailbar bordered>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "favorite"}
-                    clickable
-                    onclick={() => (selectedRoute = "favorite")}
-                  >
-                    <QIcon name="favorite" />
-                    <QItemSection>Favorites</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="favorite"
+                  label="Favorites"
+                  to="#"
+                  active={selectedRoute === "favorite"}
+                  onclick={() => (selectedRoute = "favorite")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
@@ -436,55 +421,36 @@
             <!-- Left Railbar -->
             {#snippet railbarLeft()}
               <QRailbar bordered>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
             <!-- Right Railbar -->
             {#snippet railbarRight()}
               <QRailbar side="right" bordered>
-                <QList>
-                  <QItem to="#" clickable>
-                    <QIcon name="lightbulb" />
-                    <QItemSection>Ideas</QItemSection>
-                  </QItem>
-                  <QItem to="#" clickable>
-                    <QIcon name="notifications" />
-                    <QItemSection>Alerts</QItemSection>
-                  </QItem>
-                  <QItem to="#" clickable>
-                    <QIcon name="help" />
-                    <QItemSection>Help</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem icon="lightbulb" label="Ideas" to="#" />
+                <QNavItem icon="notifications" label="Alerts" to="#" />
+                <QNavItem icon="help" label="Help" to="#" />
               </QRailbar>
             {/snippet}
 
@@ -517,35 +483,27 @@
 
             {#snippet railbarLeft()}
               <QRailbar bordered>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
@@ -582,35 +540,27 @@
 
             {#snippet railbarLeft()}
               <QRailbar bordered>
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
@@ -634,49 +584,42 @@
 
       <QDocsSection title="Styling the Railbar">
         {#snippet sectionDescription()}
-          The railbar can be styled using standard class props. Here are some styling examples.
+          Style the railbar surface with standard class props, and use <code>activeColor</code> to customize
+          its active destination indicators.
         {/snippet}
 
         <div style="height: 300px; border: 1px solid var(--outline-variant);">
           <QLayout view="hHh LpR fFf">
             {#snippet railbarLeft()}
-              <QRailbar bordered class="surface-variant">
-                <QList>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "home"}
-                    clickable
-                    onclick={() => (selectedRoute = "home")}
-                  >
-                    <QIcon name="home" />
-                    <QItemSection>Home</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "person"}
-                    clickable
-                    onclick={() => (selectedRoute = "person")}
-                  >
-                    <QIcon name="person" />
-                    <QItemSection>Profile</QItemSection>
-                  </QItem>
-                  <QItem
-                    to="#"
-                    active={selectedRoute === "settings"}
-                    clickable
-                    onclick={() => (selectedRoute = "settings")}
-                  >
-                    <QIcon name="settings" />
-                    <QItemSection>Settings</QItemSection>
-                  </QItem>
-                </QList>
+              <QRailbar bordered class="surface-variant" activeColor="primary-container">
+                <QNavItem
+                  icon="home"
+                  label="Home"
+                  to="#"
+                  active={selectedRoute === "home"}
+                  onclick={() => (selectedRoute = "home")}
+                />
+                <QNavItem
+                  icon="person"
+                  label="Profile"
+                  to="#"
+                  active={selectedRoute === "person"}
+                  onclick={() => (selectedRoute = "person")}
+                />
+                <QNavItem
+                  icon="settings"
+                  label="Settings"
+                  to="#"
+                  active={selectedRoute === "settings"}
+                  onclick={() => (selectedRoute = "settings")}
+                />
               </QRailbar>
             {/snippet}
 
             <div class="flex flex-center column" style="height: 100%">
               <h5>Styled Railbar</h5>
-              <p>This railbar uses the surface-variant background color.</p>
-              <p>You can apply any styling classes to the railbar and its contents.</p>
+              <p>This railbar uses a surface-variant background.</p>
+              <p>Its active indicator uses the primary-container color.</p>
             </div>
           </QLayout>
         </div>


### PR DESCRIPTION
## PR Type

> What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [x] Documentation
- [ ] Code style update
- [x] Refactor
- [ ] Build-related changes
- [ ] Other, please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## What's new?

> List the changes

- Adds the Material 3 `QNavbar` component with vertical and wide layouts and `QLayout` integration.
- Adds the shared `QNavItem` component for navbars and railbars, including dot and numeric badges.
- Refactors `QRailbar` to use `QNavItem`.
- Adds accessibility behavior, responsive layout handling, component CSS registration, documentation, and demos.
- Aligns styling and interactions with the current Material 3 specifications, including no default shadow and correctly bounded wide-item ripples.

## Screenshots

> If needed, you can add screenshots here

N/A

## This pull request closes an issue

> Add `Closes`, `Fixes` or `Resolves` followed by `#xxx[,#xxx]` where "xxx" is the issue number

Closes #275.